### PR TITLE
[toolchain] Move to LLVM Toolchain for OpenTitan Peripheral Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ set(CMAKE_C_STANDARD 99)
 
 # SCHEREMO: Needed to skip compiler test, which doesn't support baremetal targets
 set(CMAKE_C_COMPILER_WORKS 1)
-set(CMAKE_CXX_STANDARD 11)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 set(CMAKE_VERBOSE_MAKEFILE TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Moritz Scherer <scheremo@iis.ee.ethz.ch>
+# Viviane Potocnik <vivianep@iis.ee.ethz.ch>
 
 cmake_minimum_required(VERSION 3.13)
 
@@ -10,12 +11,16 @@ set(CMAKE_C_STANDARD 99)
 
 # SCHEREMO: Needed to skip compiler test, which doesn't support baremetal targets
 set(CMAKE_C_COMPILER_WORKS 1)
+set(CMAKE_CXX_STANDARD 11)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+set(CMAKE_VERBOSE_MAKEFILE TRUE)
 
 # SCHEREMO: Help most IDE's LSPs find definitions
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
 # SCHEREMO: This toolchain file is only used for test compilation!
-set(CMAKE_TOOLCHAIN_FILE cmake/toolchain_gcc.cmake)
+set(CMAKE_TOOLCHAIN_FILE cmake/toolchain_llvm.cmake)
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ which riscv32-unknown-elf-gcc
 ```
 is not empty.
 
+## LLVM Toolchain
+
+The applications are built using the RISC-V LLVM toolchain. On IIS systems, users can use the pre-installed LLVM version 12.0.1.
+
+Outside of IIS systems, you need to install LLVM version 12.0.1 or later to ensure compatibility.
+
+The correct version of the toolchain can be verified by running
+```
+llvm-config --version
+```
+
+## Building the SDK
+
 To build the SDK and all tests contained in the SDK, run
 
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ is not empty.
 
 The applications are built using the RISC-V LLVM toolchain. On IIS systems, users can use the pre-installed LLVM version 12.0.1.
 
-Outside of IIS systems, you need to install LLVM version 12.0.1 or later to ensure compatibility.
+Outside of IIS systems, you need to install LLVM version 12.0.1 or later to ensure compatibility. The exact command on IIS systems is:
+```
+cmake -DTARGET_PLATFORM=[YOURTARGETPLATFORM] -DTOOLCHAIN_DIR=/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0/bin ..  && cmake --build .
+```
 
 The correct version of the toolchain can be verified by running
 ```

--- a/cmake/toolchain_llvm.cmake
+++ b/cmake/toolchain_llvm.cmake
@@ -1,0 +1,20 @@
+# Copyright 2024 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Viviane Potocnik <vivianep@iis.ee.ethz.ch>
+
+set(CMAKE_EXECUTABLE_SUFFIX ".elf")
+
+set(CMAKE_SYSTEM_NAME Generic)
+
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --target=riscv32-unknown-elf")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --target=riscv32-unknown-elf")
+
+set(CMAKE_OBJCOPY llvm-objcopy)
+set(CMAKE_OBJDUMP llvm-objdump)
+set(CMAKE_AR llvm-ar)

--- a/cmake/toolchain_llvm.cmake
+++ b/cmake/toolchain_llvm.cmake
@@ -3,18 +3,21 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Viviane Potocnik <vivianep@iis.ee.ethz.ch>
+# Philip Wiese <wiesep@iis.ee.ethz.ch>
 
 set(CMAKE_EXECUTABLE_SUFFIX ".elf")
 
 set(CMAKE_SYSTEM_NAME Generic)
 
-set(CMAKE_C_COMPILER clang)
-set(CMAKE_CXX_COMPILER clang++)
-set(CMAKE_ASM_COMPILER ${CMAKE_C_COMPILER})
+set(LLVM_TAG llvm)
+
+set(CMAKE_C_COMPILER ${TOOLCHAIN_DIR}/clang)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_DIR}/clang++)
+set(CMAKE_ASM_COMPILER ${TOOLCHAIN_DIR}/clang)
+
+set(CMAKE_OBJCOPY ${TOOLCHAIN_DIR}/${LLVM_TAG}-objcopy)
+set(CMAKE_OBJDUMP ${TOOLCHAIN_DIR}/${LLVM_TAG}-objdump)
+set(CMAKE_AR ${TOOLCHAIN_DIR}/${LLVM_TAG}-ar)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --target=riscv32-unknown-elf")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --target=riscv32-unknown-elf")
-
-set(CMAKE_OBJCOPY llvm-objcopy)
-set(CMAKE_OBJDUMP llvm-objdump)
-set(CMAKE_AR llvm-ar)


### PR DESCRIPTION
### Summary

This PR transitions the `chimera-sdk` build system from GCC to the LLVM toolchain, enabling support for OpenTitan peripherals. 

#### Details

1. **LLVM Toolchain Configuration**: Introduced a new `toolchain_llvm.cmake` file.
2. **File Modifications**: Changes to the `CMakeLists.txt` file to switch to `toolchain_llvm.cmake` as the toolchain file for testing and enabled detailed compile commands and verbose output for easier debugging.