### PR TITLE
HotFix: Fix broken CMake flow

### DIFF
--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -39,7 +39,7 @@ endmacro()
 
    :param target_platform: The target platform to build for.
    :param category: The category of the subdirectories.
-   :param mappings: A list of mappings from target platforms to folders.
+   :param mappings: A list of mappings from target platforms to folders. Make sure to wrap the list in quotes!
    
    .. code-block:: cmake
       :caption Example Usage
@@ -49,7 +49,7 @@ endmacro()
           chimera-open:snitch_cluster
           chimera-host:
       )
-      add_chimera_subdirectories(${TARGET_PLATFORM} "Device" ${MAPPINGS})
+      add_chimera_subdirectories(${TARGET_PLATFORM} "Device" "${MAPPINGS}")
 
 #]=======================================================================]
 function(add_chimera_subdirectories target_platform category mappings)

--- a/devices/CMakeLists.txt
+++ b/devices/CMakeLists.txt
@@ -12,4 +12,4 @@ set(DEVICE_MAPPINGS
 )
 
 # Call the macro
-add_chimera_subdirectories(${TARGET_PLATFORM} "Device" ${DEVICE_MAPPINGS})
+add_chimera_subdirectories(${TARGET_PLATFORM} "Device" "${DEVICE_MAPPINGS}")

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -12,7 +12,7 @@ set(DRIVER_MAPPINGS
 )
 
 # Call the macro
-add_chimera_subdirectories(${TARGET_PLATFORM} "Driver" ${DRIVER_MAPPINGS})
+add_chimera_subdirectories(${TARGET_PLATFORM} "Driver" "${DRIVER_MAPPINGS}")
 
 
 # WIESEP: Export this directory as root include directory for the drivers

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,4 +13,4 @@ set(TEST_MAPPINGS
 )
 
 # Call the macro
-add_chimera_subdirectories(${TARGET_PLATFORM} "Test" ${TEST_MAPPINGS})
+add_chimera_subdirectories(${TARGET_PLATFORM} "Test" "${TEST_MAPPINGS}")


### PR DESCRIPTION
This PR fixes the CMake flow for targets other than `chimera-convolve`. The issue was that without the quotes wrapping the `mapping` argument, the list is treated as multiple arguments and not one argument containing a list. I extended the function documentation to make clear the quotes are necessary.

## Fix
- Wrap `mappings` argument in quotes