### PR TITLE
Sphinx Versioning

### DIFF
--- a/docs/src_sphinx/conf.py
+++ b/docs/src_sphinx/conf.py
@@ -58,3 +58,16 @@ breathe_default_project = "chimera_ll"
 # https://www.sphinx-doc.org/en/master/usage/extensions/todo.html
 
 todo_include_todos = True
+
+# -- Options for HTML templates ------------------------------------------------
+
+# Extract branch name from git
+branch = os.popen("git rev-parse --abbrev-ref HEAD").read().strip()
+
+html_context = {
+    'current_version':
+    f"{branch}",
+    'versions':
+    [["master", "https://pulp-platform.github.io/chimera-sdk/"],
+     ["devel", "https://pulp-platform.github.io/chimera-sdk/branch/devel/"]],
+}

--- a/docs/src_sphinx/templates/versions.html
+++ b/docs/src_sphinx/templates/versions.html
@@ -1,0 +1,26 @@
+<div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
+  <span class="rst-current-version" data-toggle="rst-current-version">
+    Version: {{ current_version }}
+    <span class="fa fa-caret-down"></span>
+  </span>
+  <div class="rst-other-versions">
+    {% if languages|length >= 1 %}
+    <dl>
+      <dt>{{ _('Languages') }}</dt>
+      {% for the_language, url in languages %}
+      <dd><a href="{{ url }}/index.html">{{ the_language }}</a></dd>
+      {% endfor %}
+    </dl>
+    {% endif %}
+    {% if versions|length >= 1 %}
+    <dl>
+      <dt>{{ _('Versions') }}</dt>
+      {% for the_version, url in versions %}
+      <dd><a href="{{ url }}/index.html">{{ the_version }}</a></dd>
+      {% endfor %}
+    </dl>
+    {% endif %}
+    <br>
+    </dl>
+  </div>
+</div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+#
+# Copyright 2024 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+# 
+# Philip Wiese <wiesep@iis.ee.ethz.ch>
+#
+
+yapf=0.33.0


### PR DESCRIPTION
# Changelog

This merge request updates the Sphinx documentation and adds functionality to select the version. The different documentation version for different branches can be selected in the left sidebar.

You can view the documentation with the changes implemented at: [Chimera SDK Documentation Example](https://xeratec.github.io/chimera-sdk/branch/pr--doc_versioning/index.html)

## Added
- Functionality to extract the current Git branch name using `git rev-parse --abbrev-ref HEAD`.
- Integration of the branch name into the Sphinx HTML templates for improved documentation versioning and clarity.

## Changed
- Updates to `conf.py` in the Sphinx documentation source to support dynamic branch name handling.