### PR TITLE
Fix Linker Issues and Update Build Documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,15 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 # SCHEREMO: This toolchain file is only used for test compilation!
 set(CMAKE_TOOLCHAIN_FILE cmake/toolchain_llvm.cmake)
 
+# WIESEP: We currently use the GCC riscv32-unknown-elf-ld linker instead of LLVM lld linker
+find_program(RISCV32_UNKNOWN_ELF_LD riscv32-unknown-elf-ld)
+if(NOT RISCV32_UNKNOWN_ELF_LD)
+    message(FATAL_ERROR "riscv32-unknown-elf-ld not found. Make sure it can be found in your PATH.")
+else()
+    set(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=${RISCV32_UNKNOWN_ELF_LD}")
+    message(STATUS "Found linker: ${RISCV32_UNKNOWN_ELF_LD}")
+endif()
+
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,15 +22,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 # SCHEREMO: This toolchain file is only used for test compilation!
 set(CMAKE_TOOLCHAIN_FILE cmake/toolchain_llvm.cmake)
 
-# WIESEP: We currently use the GCC riscv32-unknown-elf-ld linker instead of LLVM lld linker
-find_program(RISCV32_UNKNOWN_ELF_LD riscv32-unknown-elf-ld)
-if(NOT RISCV32_UNKNOWN_ELF_LD)
-    message(FATAL_ERROR "riscv32-unknown-elf-ld not found. Make sure it can be found in your PATH.")
-else()
-    set(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=${RISCV32_UNKNOWN_ELF_LD}")
-    message(STATUS "Found linker: ${RISCV32_UNKNOWN_ELF_LD}")
-endif()
-
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/cmake/toolchain_llvm.cmake
+++ b/cmake/toolchain_llvm.cmake
@@ -22,11 +22,10 @@ set(CMAKE_AR ${TOOLCHAIN_DIR}/bin/${LLVM_TAG}-ar)
 # Disable ABI detection
 set(CMAKE_C_ABI_COMPILED "False")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --target=riscv32-unknown-elf")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --target=riscv32-unknown-elf")
+add_compile_options("--target=riscv32-unknown-elf")
 
 # Use LLVM LLD linker
-set(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=lld")
+add_link_options("-fuse-ld=lld")
 
 # Check LLVM version
 execute_process(
@@ -43,10 +42,6 @@ string(REGEX MATCH "[0-9]+$" LLVM_VERSION_PATCH ${LLVM_VERSION})
 if (LLVM_VERSION_MAJOR LESS 15)
     message(STATUS "Disable linker relaxation for LLVM < 15")
     # WIESEP: Disable linker relaxation for LLVM 12
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mno-relax")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-relax")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-relax")
-
-    # Also for ASM files
-    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -mno-relax")
+    add_compile_options("-mno-relax")
+    add_link_options("-Wl,--no-relax")
 endif()

--- a/cmake/toolchain_llvm.cmake
+++ b/cmake/toolchain_llvm.cmake
@@ -11,13 +11,16 @@ set(CMAKE_SYSTEM_NAME Generic)
 
 set(LLVM_TAG llvm)
 
-set(CMAKE_C_COMPILER ${TOOLCHAIN_DIR}/clang)
-set(CMAKE_CXX_COMPILER ${TOOLCHAIN_DIR}/clang++)
-set(CMAKE_ASM_COMPILER ${TOOLCHAIN_DIR}/clang)
+set(CMAKE_C_COMPILER ${TOOLCHAIN_DIR}/bin/clang)
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_DIR}/bin/clang++)
+set(CMAKE_ASM_COMPILER ${TOOLCHAIN_DIR}/bin/clang)
 
-set(CMAKE_OBJCOPY ${TOOLCHAIN_DIR}/${LLVM_TAG}-objcopy)
-set(CMAKE_OBJDUMP ${TOOLCHAIN_DIR}/${LLVM_TAG}-objdump)
-set(CMAKE_AR ${TOOLCHAIN_DIR}/${LLVM_TAG}-ar)
+set(CMAKE_OBJCOPY ${TOOLCHAIN_DIR}/bin/${LLVM_TAG}-objcopy)
+set(CMAKE_OBJDUMP ${TOOLCHAIN_DIR}/bin/${LLVM_TAG}-objdump)
+set(CMAKE_AR ${TOOLCHAIN_DIR}/bin/${LLVM_TAG}-ar)
+
+# Disable ABI detection
+set(CMAKE_C_ABI_COMPILED "False")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --target=riscv32-unknown-elf")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --target=riscv32-unknown-elf")

--- a/cmake/toolchain_llvm.cmake
+++ b/cmake/toolchain_llvm.cmake
@@ -24,3 +24,29 @@ set(CMAKE_C_ABI_COMPILED "False")
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --target=riscv32-unknown-elf")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --target=riscv32-unknown-elf")
+
+# Use LLVM LLD linker
+set(CMAKE_EXE_LINKER_FLAGS "-fuse-ld=lld")
+
+# Check LLVM version
+execute_process(
+    COMMAND ${CMAKE_C_COMPILER} --version
+    OUTPUT_VARIABLE LLVM_VERSION
+)
+string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" LLVM_VERSION ${LLVM_VERSION})
+
+# Get Major version
+string(REGEX MATCH "^[0-9]+" LLVM_VERSION_MAJOR ${LLVM_VERSION})
+string(REGEX MATCH "[0-9]+$" LLVM_VERSION_MINOR ${LLVM_VERSION})
+string(REGEX MATCH "[0-9]+$" LLVM_VERSION_PATCH ${LLVM_VERSION})
+
+if (LLVM_VERSION_MAJOR LESS 15)
+    message(STATUS "Disable linker relaxation for LLVM < 15")
+    # WIESEP: Disable linker relaxation for LLVM 12
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mno-relax")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-relax")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--no-relax")
+
+    # Also for ASM files
+    set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -mno-relax")
+endif()

--- a/docs/src_sphinx/usage/usage.rst
+++ b/docs/src_sphinx/usage/usage.rst
@@ -4,11 +4,10 @@ Usage
 Building the SDK
 ----------------
 
-The applications are built with RISC-V LLVM 12.0.1 or later to ensure compatibility. 
-However, the SDK uses the GNU linker (``riscv32-unknown-elf-ld``) instead of the LLVM linker (``lld``) due to compatibility issues.
+The applications are built with RISC-V LLVM 12.0.1 or later to ensure compatibility.
 
-.. warning::
-    Ensure that ``riscv32-unknown-elf-ld`` locatable in your ``PATH``.
+.. important::
+    For LLVM versions less than 15, linker relaxation is not supported and thus disabled.
 
 
 Generic Environment
@@ -35,7 +34,7 @@ IIS Workstations
 ^^^^^^^^^^^^^^^^
 
 On IIS systems, users can use the pre-installed LLVM compiler by activating the riscv environment with the ``riscv`` command.
-This command sets the necessary environment variables for the toolchain. 
+This command sets the necessary environment variables for the toolchain.
 To build the SDK, run:
 
 .. code-block:: bash
@@ -65,9 +64,6 @@ To enable automatic configuration of the C/C++ extension and support for the int
             "TOOLCHAIN_DIR": "/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0",
             "TARGET_PLATFORM": "chimera-convolve",
         },
-        "cmake.environment": {
-            "PATH": "/usr/pack/riscv-1.0-kgf/default/bin:${env:PATH}",
-        }
     }
 
 If you are not on an IIS system, you need to adjust the paths according to your local installation.

--- a/docs/src_sphinx/usage/usage.rst
+++ b/docs/src_sphinx/usage/usage.rst
@@ -4,31 +4,45 @@ Usage
 Building the SDK
 ----------------
 
+The applications are built with RISC-V LLVM 12.0.1 or later to ensure compatibility. 
+However, the SDK uses the GNU linker (``riscv32-unknown-elf-ld``) instead of the LLVM linker (``lld``) due to compatibility issues.
+
+.. warning::
+    Ensure that ``riscv32-unknown-elf-ld`` locatable in your ``PATH``.
+
+
+Generic Environment
+^^^^^^^^^^^^^^^^^^^
+
 To build the SDK and all tests contained in the SDK, run:
 
 .. code-block:: bash
 
-    mkdir build && cd build
-    cmake -DTARGET_PLATFORM=[YOURTARGETPLATFORM] ../
-    cmake --build .
+    cmake -DTARGET_PLATFORM=<target> -B build
+    cmake --build build -j
 
 where you should replace ``[YOURTARGETPLATFORM]`` by one of the platforms defined in ``targets/CMakeLists.txt`` under ``AVAILABLE_TARGETS``.
 The resulting binaries will be stored in ``build/bin``, and can be used within the ``chimera`` repo as tests.
 
-The applications are built using the RISC-V LLVM toolchain. On IIS systems, users can use the pre-installed LLVM version 12.0.1.
-Outside of IIS systems, you need to install LLVM version 12.0.1 or later to ensure compatibility. Thus you need to specify the ``TOOLCHAIN_DIR`` parameter when running cmake. 
+If you did not globally install the toolchain, you need to specify the ``TOOLCHAIN_DIR`` parameter when running cmake.
 
 .. code-block:: bash
 
-    mkdir build && cd build
-    cmake -DTARGET_PLATFORM=[YOURTARGETPLATFORM] -DTOOLCHAIN_DIR=/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0/bin ../
-    cmake --build .
+    cmake -DTARGET_PLATFORM=<target> -DTOOLCHAIN_DIR=<path-to-toolchain> ../
+    cmake --build build -j
 
-The correct version of the toolchain can be verified by running
+IIS Workstations
+^^^^^^^^^^^^^^^^
+
+On IIS systems, users can use the pre-installed LLVM compiler by activating the riscv environment with the ``riscv`` command.
+This command sets the necessary environment variables for the toolchain. 
+To build the SDK, run:
 
 .. code-block:: bash
 
-    llvm-config --version
+    riscv zsh # Setup the default riscv environment (modifies PATH and LD_LIBRARY_PATH)
+    cmake -DTARGET_PLATFORM=<target> -DTOOLCHAIN_DIR=/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0 -B build
+    cmake --build build -j
 
 
 Targets
@@ -48,12 +62,11 @@ To enable automatic configuration of the C/C++ extension and support for the int
 
     {
         "cmake.configureSettings": {
-            "TOOLCHAIN_DIR": "/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0/bin",
+            "TOOLCHAIN_DIR": "/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0",
             "TARGET_PLATFORM": "chimera-convolve",
         },
         "cmake.environment": {
             "PATH": "/usr/pack/riscv-1.0-kgf/default/bin:${env:PATH}",
-            "LD_LIBRARY_PATH": "/usr/pack/riscv-1.0-kgf/lib64:/usr/pack/riscv-1.0-kgf/lib64",
         }
     }
 

--- a/tests/chimera-open/snitchCluster/simpleOffload/src_cluster/test_cluster.c
+++ b/tests/chimera-open/snitchCluster/simpleOffload/src_cluster/test_cluster.c
@@ -22,8 +22,6 @@ __attribute__((naked)) void clusterInterruptHandler() {
     asm volatile(
         // Load mhartid CSR into t0
         "csrr t0, mhartid\n"
-        // Load the base address of clintPointer into t1
-        // "lw t1, %0\n"
 
         // Load clint base address into t1
         "la t1, __base_clint\n"


### PR DESCRIPTION
# Problem Statement
The current flow uses the LLVM toolchain for compilation but the GNU linker (`riscv32-unknown-elf-ld`) instead of the LLVM linker (``lld``). Previously, this was not clearly stated in the documentation and not checked in the CMake flow causing potential linking problems. Consequently, on the current `devel` branch, the default linker at `/usr/bin/ld` on the IIS workstation is used if no other appropriate linker can be found in the `PATH` environment variable:
```
[ 83%] Linking C executable ../../../../bin/test_snitchCluster_simpleOffload
/usr/bin/ld: unrecognised emulation mode: elf32lriscv
Supported emulations: elf_x86_64 elf32_x86_64 elf_i386 elf_iamcu i386linux elf_l1om elf_k1om i386pep i386pe
clang-12: error: ld command failed with exit code 1 (use -v to see invocation)
```

# Changelog
This PR introduces updates to the SDK build process, toolchain configuration, and documentation. The deployed documentation can be accessed via https://xeratec.github.io/chimera-sdk/branch/pr--readme/usage/usage.html

## Added
- ~Added checks to ensure the `riscv32-unknown-elf-ld` linker is available in the system's `PATH`.~
- ~Added a warning about ensuring the GNU linker is accessible during builds.~
- Disable linker relaxation for LLVM versions less than 15

## Changed
- Enhanced usage instructions.
- Removed `/bin` from `TOOLCHAIN_DIR`
- Added information on using the `riscv` environment on IIS systems.

## Fixed
- Disabled ABI detection, which failed anyways.
- Removed unnecessary entries for VSCode configuration.
​
## Checklist
- [x] Rebase onto `devel` after merging #23 
