### PR TITLE
Fixup driver header file

### DIFF
--- a/drivers/cluster/CMakeLists.txt
+++ b/drivers/cluster/CMakeLists.txt
@@ -13,3 +13,4 @@ file(GLOB_RECURSE C_SOURCES
 )
 
 target_sources(runtime_host PRIVATE ${C_SOURCES})
+target_compile_definitions(runtime_host INTERFACE CHIMERA_DRIVER_CLUSTER)

--- a/drivers/driver.h
+++ b/drivers/driver.h
@@ -8,6 +8,8 @@
 #define _DRIVER_INCLUDE_GUARD_
 
 // WIESEP: Common header for all drivers
+#ifdef CHIMERA_DRIVER_CLUSTER
 #include "cluster/offload_snitchCluster.h"
+#endif
 
 #endif //_DRIVER_INCLUDE_GUARD_


### PR DESCRIPTION
This PR ensures driver subdirectories only get their header globally included iff they are included in the respective mapping.