### PR TITLE
Fix CMake Compatibility, Core Setup, and Add GitHub Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ''
+
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## To Reproduce
+Steps to reproduce the behavior:
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for Deeploy
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+## Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for Deeploy
+about: Suggest an idea for Chimera-SDK
 title: ''
 labels: enhancement
 assignees: ''
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 ## Is your feature request related to a problem? Please describe.
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is. Ex. The process to do X is very lengthy. By adding Y, we could make X be much faster.
 
 ## Describe the solution you'd like
 A clear and concise description of what you want to happen.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+# Changelog
+Describe the intent of your PR here.
+
+## Added
+-
+
+## Changed
+-
+
+## Fixed
+-
+
+## Checklist
+
+1. [ ] The PR is rebased on the latest `devel` commit and pointing to `devel`.
+2. [ ] Your PR reviewed and approved.
+2. [ ] The documentation is updated.
+3. [ ] All checks are passing.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ add_subdirectory(drivers)
 set(VALID_TEST_MODES "simulation" "none")
 
 # Option for TEST_MODE with default value
-option(TEST_MODE "Set what validation target the tests should be run on" "none")
+set(TEST_MODE "none" CACHE STRING "Set what validation target the tests should be run on")
 
 # Check if TEST_MODE is set to a valid option
 if(NOT TEST_MODE IN_LIST VALID_TEST_MODES)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ setup:
 
 format:
 	@echo "Formatting code..."
-	@python scripts/run_clang_format.py -ir tests/ hal/ targets/ drivers/ --clang-format-executable=$(CLANG_FORMAT_EXECUTABLE)
+	@python scripts/run_clang_format.py -ir tests/ hal/ targets/ drivers/ devices/ --clang-format-executable=$(CLANG_FORMAT_EXECUTABLE)
 	@python -m yapf -rip .
 
 .PHONY: format help

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,6 @@ help:
 	@echo ""
 	@echo "Available Targets:"
 	@echo " - format: Format all code"
-	@echo " - setup: Install dependencies"
-
-setup:
-	@echo "Installing dependencies..."
-	@pip install -r requirements.txt
 
 format:
 	@echo "Formatting code..."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+# Copyright 2025 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Author: Philip Wiese <wiesep@iis.ee.ethz.ch>
+
+CLANG_FORMAT_EXECUTABLE ?= clang-format
+
+help:
+	@echo "Usage: make <target>"
+	@echo ""
+	@echo "Available Targets:"
+	@echo " - format: Format all code"
+	@echo " - setup: Install dependencies"
+
+setup:
+	@echo "Installing dependencies..."
+	@pip install -r requirements.txt
+
+format:
+	@echo "Formatting code..."
+	@python scripts/run_clang_format.py -ir tests/ hal/ targets/ drivers/ --clang-format-executable=$(CLANG_FORMAT_EXECUTABLE)
+	@python -m yapf -rip .
+
+.PHONY: format help

--- a/README.md
+++ b/README.md
@@ -10,27 +10,20 @@ Unless specified otherwise in the respective file headers, all code checked into
 
 ## Documentation
 All revelevant documentation can be found in the `docs` folder and is hosted on GitHub Pages.
-Access the documentation on 
+Access the documentation on
 - [Master Branch](https://pulp-platform.github.io/chimera-sdk/)
 - [Devel Branch](https://pulp-platform.github.io/chimera-sdk/branch/devel)
 
 The documentation for a specific branch can be accessed via `https://pulp-platform.github.io/chimera-sdk/branch/<branch>`
 
 ## Contributing
-### CXX Formatting
-To format all source files, run
-```
-python scripts/run_clang_format.py -ir hal/ targets/ tests/ drivers/
-```
+### Formatting
+To simplify formatting of the code, we provide a Makefiles target that runs clang-format on all source files.
+To install all required dependencies and run the formatter run:
 
-Our CI uses llvm-12 for clang-format, so on IIS machines you may run
-```
-python scripts/run_clang_format.py -ir tests/ hal/ targets/ drivers/ --clang-format-executable=/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0/bin/clang-format
-```
-
-### Python Formatting
-To format all python files, run
 ```bash
-python -m yapf -rip .
+make setup
+make format
 ```
 
+**The Makefile is only used for utility purposes and not by the build system.!**

--- a/README.md
+++ b/README.md
@@ -19,10 +19,18 @@ The documentation for a specific branch can be accessed via `https://pulp-platfo
 ## Contributing
 ### Formatting
 To simplify formatting of the code, we provide a Makefiles target that runs clang-format on all source files.
-To install all required dependencies and run the formatter run:
+We recomment that you setup a virtual environment and install the required dependencies using the following commands:
 
 ```bash
-make setup
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+Alternatively you can also use any mamba/conda environment.
+
+Then, to format the code, run the following command:
+
+```bash
 make format
 ```
 

--- a/devices/snitch_cluster/CMakeLists.txt
+++ b/devices/snitch_cluster/CMakeLists.txt
@@ -13,3 +13,4 @@ file(GLOB_RECURSE C_SOURCES_SNITCH
 )
 
 target_sources(runtime_cluster_snitch PRIVATE ${C_SOURCES_SNITCH})
+target_include_directories(runtime_cluster_snitch PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/devices/snitch_cluster/trampoline_snitchCluster.c
+++ b/devices/snitch_cluster/trampoline_snitchCluster.c
@@ -30,7 +30,7 @@ extern void *_trampoline_stack;
  */
 // WIESEP: Make sure the compiler does not allocate a stack frame
 void __attribute__((naked)) _trampoline() {
-    SNITCH_SETUP_CORE();
+    _SETUP_GP_TP();
 
     asm volatile(
         // Get hart ID (hardware thread ID)

--- a/devices/snitch_cluster/trampoline_snitchCluster.c
+++ b/devices/snitch_cluster/trampoline_snitchCluster.c
@@ -10,6 +10,8 @@
 
 #include <stdint.h>
 
+#include "trampoline_snitchCluster.h"
+
 // Persistent trampoline function pointer for each core
 extern void (*_trampoline_function)(void *);
 
@@ -28,18 +30,11 @@ extern void *_trampoline_stack;
  */
 // WIESEP: Make sure the compiler does not allocate a stack frame
 void __attribute__((naked)) _trampoline() {
+    SNITCH_SETUP_CORE();
+
     asm volatile(
         // Get hart ID (hardware thread ID)
         "csrr t1, mhartid\n" // Load mhartid into a0
-
-        // Load global pointer
-        ".option push\n"
-        ".option norelax\n"          // Disable relaxation to ensure `la` behaves as expected
-        "la gp, __global_pointer$\n" // Load address of global pointer
-        ".option pop\n"
-
-        // Set thread pointer (tp) to zero
-        "mv tp, zero\n"
 
         // Set up stack pointer
         "la a0, _trampoline_stack\n" // Load address of _trampoline_stack

--- a/devices/snitch_cluster/trampoline_snitchCluster.h
+++ b/devices/snitch_cluster/trampoline_snitchCluster.h
@@ -18,7 +18,7 @@
  *
  * This function will set up the global pointer and thread pointer for the core.
  */
-#define SNITCH_SETUP_CORE() \
+#define _SETUP_GP_TP() \
     asm volatile(".option push\n" \
                  ".option norelax\n" \
                  "la gp, __global_pointer$\n" \

--- a/devices/snitch_cluster/trampoline_snitchCluster.h
+++ b/devices/snitch_cluster/trampoline_snitchCluster.h
@@ -1,0 +1,36 @@
+
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Philip Wiese <wiesep@iis.ee.ethz.ch>
+
+#ifndef _CLUSTER_SNITCH_TRAMPOLINE_INCLUDE_GUARD_
+#define _CLUSTER_SNITCH_TRAMPOLINE_INCLUDE_GUARD_
+
+#include <stdint.h>
+
+/** \addtogroup devices_snitchCluster
+ *  @{
+ */
+
+/**
+ * @brief Setup the core to a known state.
+ *
+ * This function will set up the global pointer and thread pointer for the core.
+ */
+#define SNITCH_SETUP_CORE()                     \
+    asm volatile(                               \
+        ".option push\n"                        \
+        ".option norelax\n"                     \
+        "la gp, __global_pointer$\n"            \
+        ".option pop\n"                         \
+        "mv tp, zero\n"                         \
+        : /* No outputs */                      \
+        : /* No inputs */                       \
+        : /* No clobbered registers */)
+
+/** @} */
+
+#endif //_CLUSTER_SNITCH_TRAMPOLINE_INCLUDE_GUARD_
+

--- a/devices/snitch_cluster/trampoline_snitchCluster.h
+++ b/devices/snitch_cluster/trampoline_snitchCluster.h
@@ -1,4 +1,3 @@
-
 // Copyright 2024 ETH Zurich and University of Bologna.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
@@ -19,18 +18,16 @@
  *
  * This function will set up the global pointer and thread pointer for the core.
  */
-#define SNITCH_SETUP_CORE()                     \
-    asm volatile(                               \
-        ".option push\n"                        \
-        ".option norelax\n"                     \
-        "la gp, __global_pointer$\n"            \
-        ".option pop\n"                         \
-        "mv tp, zero\n"                         \
-        : /* No outputs */                      \
-        : /* No inputs */                       \
-        : /* No clobbered registers */)
+#define SNITCH_SETUP_CORE() \
+    asm volatile(".option push\n" \
+                 ".option norelax\n" \
+                 "la gp, __global_pointer$\n" \
+                 ".option pop\n" \
+                 "mv tp, zero\n" \
+                 : /* No outputs */ \
+                 : /* No inputs */ \
+                 : /* No clobbered registers */)
 
 /** @} */
 
 #endif //_CLUSTER_SNITCH_TRAMPOLINE_INCLUDE_GUARD_
-

--- a/drivers/cluster/offload_snitchCluster.h
+++ b/drivers/cluster/offload_snitchCluster.h
@@ -4,8 +4,8 @@
 //
 // Philip Wiese <wiesep@iis.ee.ethz.ch>
 
-#ifndef _OFFLOAD_INCLUDE_GUARD_
-#define _OFFLOAD_INCLUDE_GUARD_
+#ifndef _CLUSTER_SNITCH_OFFLOAD_INCLUDE_GUARD_
+#define _CLUSTER_SNITCH_OFFLOAD_INCLUDE_GUARD_
 
 #include <stdint.h>
 
@@ -33,4 +33,4 @@ uint32_t wait_snitchCluster_return(uint8_t clusterId);
 
 /** @} */
 
-#endif //_OFFLOAD_INCLUDE_GUARD_
+#endif //_CLUSTER_SNITCH_OFFLOAD_INCLUDE_GUARD_

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 # Copyright 2024 ETH Zurich and University of Bologna.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-# 
+#
 # Philip Wiese <wiesep@iis.ee.ethz.ch>
 #
 
-yapf=0.33.0
+yapf==0.33.0

--- a/tests/chimera-open/snitchCluster/simpleOffload/src_cluster/test_cluster.c
+++ b/tests/chimera-open/snitchCluster/simpleOffload/src_cluster/test_cluster.c
@@ -17,7 +17,7 @@
  * @warning Stack, thread and global pointer might not yet be set up!
  */
 __attribute__((naked)) void clusterInterruptHandler() {
-    SNITCH_SETUP_CORE();
+    _SETUP_GP_TP();
 
     asm volatile(
         // Load mhartid CSR into t0

--- a/tests/chimera-open/snitchCluster/simpleOffload/src_cluster/test_cluster.c
+++ b/tests/chimera-open/snitchCluster/simpleOffload/src_cluster/test_cluster.c
@@ -9,7 +9,9 @@
 
 #include "soc.h"
 
-static uint32_t *clintPointer = (uint32_t *)CLINT_CTRL_BASE;
+#include "trampoline_snitchCluster.h"
+
+uint32_t *clintPointer = (uint32_t *)CLINT_CTRL_BASE;
 
 /**
  * @brief Interrupt handler for the cluster, which clears the interrupt flag for the current hart.
@@ -17,27 +19,23 @@ static uint32_t *clintPointer = (uint32_t *)CLINT_CTRL_BASE;
  * @warning Stack, thread and global pointer might not yet be set up!
  */
 __attribute__((naked)) void clusterInterruptHandler() {
+    SNITCH_SETUP_CORE();
+
     asm volatile(
-        // Load global pointer
-        ".option push\n"
-        ".option norelax\n"          // Disable relaxation to ensure `la` behaves as expected
-        "la gp, __global_pointer$\n" // Load address of global pointer
-        ".option pop\n"
-
-        // Set thread pointer (tp) to zero
-        "mv tp, zero\n"
-
         // Load mhartid CSR into t0
         "csrr t0, mhartid\n"
         // Load the base address of clintPointer into t1
-        "lw t1, %0\n"
+        // "lw t1, %0\n"
+        "lui t1, %%hi(clintPointer)\n"
+        "addi t1, t1, %%lo(clintPointer)\n"
+
         // Calculate the interrupt target address: t1 = t1 + (t0 * 4)
         "slli t0, t0, 2\n"
         "add t1, t1, t0\n"
         // Store 0 to the interrupt target address
         "sw zero, 0(t1)\n"
         "ret"
-        :
+        :                   // No outputs
         : "m"(clintPointer) // Pass clintPointer as input
         : "t0", "t1"        // Declare clobbered registers
     );

--- a/tests/chimera-open/snitchCluster/simpleOffload/src_cluster/test_cluster.c
+++ b/tests/chimera-open/snitchCluster/simpleOffload/src_cluster/test_cluster.c
@@ -11,8 +11,6 @@
 
 #include "trampoline_snitchCluster.h"
 
-uint32_t *clintPointer = (uint32_t *)CLINT_CTRL_BASE;
-
 /**
  * @brief Interrupt handler for the cluster, which clears the interrupt flag for the current hart.
  *
@@ -26,8 +24,9 @@ __attribute__((naked)) void clusterInterruptHandler() {
         "csrr t0, mhartid\n"
         // Load the base address of clintPointer into t1
         // "lw t1, %0\n"
-        "lui t1, %%hi(clintPointer)\n"
-        "addi t1, t1, %%lo(clintPointer)\n"
+
+        // Load clint base address into t1
+        "la t1, __base_clint\n"
 
         // Calculate the interrupt target address: t1 = t1 + (t0 * 4)
         "slli t0, t0, 2\n"
@@ -35,9 +34,9 @@ __attribute__((naked)) void clusterInterruptHandler() {
         // Store 0 to the interrupt target address
         "sw zero, 0(t1)\n"
         "ret"
-        :                   // No outputs
-        : "m"(clintPointer) // Pass clintPointer as input
-        : "t0", "t1"        // Declare clobbered registers
+        :            // No outputs
+        :            // No inputs
+        : "t0", "t1" // Declare clobbered registers
     );
 }
 


### PR DESCRIPTION
# Changelog
This PR fixes compatibility problems with CMake 3.20 and a broken core setup functions. The issue was that the global pointer was sometimes accessed before properly initialized. Additionally, this PR adds a Makefile to simplify formatting, issue and merge templates and some minor changes.

Thanks to @arpansur for pointing out issues with the core setup functions.

## Added
- Add Makefile to simplify formatting
- Add GitHub templates
- Extract snitch core setup into reusable macro

## Changed
- Change some include guards to align naming

## Fixed
- Fix TEST_MODE variable
- Fix broken core setup functions 
- Fix broken `requirements.txt`

