### PR TITLE
GitLab CI for GVSoC tests and standardized GVSoC install flow

### DIFF
--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -1,0 +1,16 @@
+name: gitlab-ci
+
+on: [ push, pull_request, workflow_dispatch ]
+
+jobs:
+  gitlab-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Gitlab CI
+        uses: pulp-platform/pulp-actions/gitlab-ci@v2.4.1 # update version as needed, not auto-updated
+        # Skip on forks or pull requests from forks due to missing secrets.
+        if: github.repository == 'Victor-Jung/chimera-sdk' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        with:
+          domain: iis-git.ee.ethz.ch
+          repo: github-mirror/chimera-sdk
+          token: ${{ secrets.GITLAB_TOKEN }}

--- a/.github/workflows/gitlab-ci.yml
+++ b/.github/workflows/gitlab-ci.yml
@@ -1,3 +1,9 @@
+# Copyright 2025 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Author: Victor Jung <jungvi@iis.ee.ethz.ch>
+
 name: gitlab-ci
 
 on: [ push, pull_request, workflow_dispatch ]

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__
 # Documentation
 docs/_build
 docs/_autosummary
+
+# Dept Install Dir
+simulator_install

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ docs/_build
 docs/_autosummary
 
 # Dept Install Dir
-simulator_install
+install

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -7,8 +7,8 @@ stages: # List of stages for jobs with their order of execution
 .setup:
   script:
     - bash 
-    - export $CMAKE='/usr/sepp/bin/cmake-3.18.1'
-    - export $LLVM_INSTALL_PATH='/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0'
+    - export CMAKE='/usr/sepp/bin/cmake-3.18.1'
+    - export LLVM_INSTALL_PATH='/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0'
 
 build_sdk:
   stage: build

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -11,8 +11,8 @@ stages: # List of stages for jobs with their order of execution
 .setup:
   script:
     - bash 
-    - /scratch/jungvi/Chimera-sdk-ci/mamba_setup.sh
-    - mamba activate chimera-sdk-ci
+    - eval "$(micromamba shell hook --shell bash)"
+    - micromamba activate chimera-sdk-ci
     - export CMAKE='/usr/sepp/bin/cmake-3.18.1'
     - export LLVM_INSTALL_PATH='/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0'
 

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -11,6 +11,8 @@ stages: # List of stages for jobs with their order of execution
 .setup:
   script:
     - bash 
+    - ./scratch/jungvi/Chimera-sdk-ci/mamba_setup.sh
+    - mamba activate chimera-sdk-ci
     - export CMAKE='/usr/sepp/bin/cmake-3.18.1'
     - export LLVM_INSTALL_PATH='/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0'
 

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -35,7 +35,6 @@ test:
         TEST: [test_host_returnZero, test_snitchCluster_simpleOffload]
       - TARGET: [chimera-host, chimera-convolve]
         TEST: [test_host_returnZero]
-  # resource_group: gvsoc_test_jobs_group
   script:
     - !reference [.setup, script]
     - $CMAKE -DTARGET_PLATFORM=$TARGET -DTOOLCHAIN_DIR=$LLVM_INSTALL_PATH -B build

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -7,8 +7,8 @@ stages: # List of stages for jobs with their order of execution
 .setup:
   script:
     - bash 
-    - export $CMAKE=/usr/sepp/bin/cmake-3.18.1
-    - export $LLVM_INSTALL_PATH=/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0
+    - export $CMAKE='/usr/sepp/bin/cmake-3.18.1'
+    - export $LLVM_INSTALL_PATH='/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0'
 
 build_sdk:
   stage: build

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -40,4 +40,4 @@ test:
     - cd ${GVSOC_HOME}
     - echo $CI_PROJECT_DIR
     - echo $CI_PROJECT_PATH
-    - ./install/bin/gvsoc --target=chimera --binary $CI_PROJECT_DIR/build/$TEST image run
+    - ./install/bin/gvsoc --target=chimera --binary $CI_PROJECT_DIR/build/bin/$TEST image run

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -6,7 +6,7 @@
 
 stages: # List of stages for jobs with their order of execution
   - build
-  # - test
+  - test
 
 .setup:
   script:
@@ -15,6 +15,7 @@ stages: # List of stages for jobs with their order of execution
     - micromamba activate chimera-sdk-ci
     - export CMAKE='/usr/sepp/bin/cmake-3.18.1'
     - export LLVM_INSTALL_PATH='/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0'
+    - export GVSOC_HOME='/scratch/jungvi/chimera-sdk/simulator_install/gvsoc'
 
 build_sdk:
   stage: build
@@ -25,3 +26,16 @@ build_sdk:
     - !reference [.setup, script]
     - $CMAKE -DTARGET_PLATFORM=$TARGET -DTOOLCHAIN_DIR=$LLVM_INSTALL_PATH -B build
     - $CMAKE --build build -j
+
+test:
+  stage: test
+  parallel:
+    matrix:
+      - TARGET: [chimera-open, chimera-host, chimera-convolve]
+        TEST: [test_host_returnZero, test_snitchCluster_simpleOffload]
+  script:
+    - !reference [.setup, script]
+    - $CMAKE -DTARGET_PLATFORM=$TARGET -DTOOLCHAIN_DIR=$LLVM_INSTALL_PATH -B build
+    - $CMAKE --build build -j
+    - cd ${GVSOC_HOME}
+    - ./install/bin/gvsoc --target=chimera --binary $CI_PROJECT_DIR/build/$TEST hello image run

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 
 
-stages: # List of stages for jobs, and their order of execution
+stages: # List of stages for jobs with their order of execution
   - build
   # - test
 

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -1,0 +1,21 @@
+
+
+stages: # List of stages for jobs, and their order of execution
+  - build
+  # - test
+
+.setup:
+  script:
+    - bash 
+    - export $CMAKE=/usr/sepp/bin/cmake-3.18.1
+    - export $LLVM_INSTALL_PATH=/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0
+
+build_sdk:
+  stage: build
+  parallel:
+    matrix:
+      - TARGET: [chimera-open, chimera-host, chimera-convolve]
+  script:
+    - !reference [.setup, script]
+    - $CMAKE -DTARGET_PLATFORM=$TARGET -DTOOLCHAIN_DIR=$LLVM_INSTALL_PATH -B build
+    - $CMAKE --build build -j

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -18,6 +18,7 @@ stages: # List of stages for jobs with their order of execution
     - bash 
     - eval "$(micromamba shell hook --shell bash)"
     - micromamba activate chimera-sdk-ci
+    - rm -rf build
 
 build_sdk:
   stage: build

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -38,4 +38,6 @@ test:
     - $CMAKE -DTARGET_PLATFORM=$TARGET -DTOOLCHAIN_DIR=$LLVM_INSTALL_PATH -B build
     - $CMAKE --build build -j
     - cd ${GVSOC_HOME}
-    - ./install/bin/gvsoc --target=chimera --binary $CI_PROJECT_DIR/build/$TEST hello image run
+    - echo $CI_PROJECT_DIR
+    - echo $CI_PROJECT_PATH
+    - ./install/bin/gvsoc --target=chimera --binary $CI_PROJECT_DIR/build/$TEST image run

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -1,4 +1,8 @@
+# Copyright 2025 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
 
+# Author: Victor Jung <jungvi@iis.ee.ethz.ch>
 
 stages: # List of stages for jobs with their order of execution
   - build

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -4,6 +4,11 @@
 
 # Author: Victor Jung <jungvi@iis.ee.ethz.ch>
 
+variables:
+  CMAKE: '/usr/sepp/bin/cmake-3.18.1'
+  LLVM_INSTALL_PATH: '/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0'
+  GVSOC_HOME: '/scratch/jungvi/chimera-sdk/install/gvsoc'
+
 stages: # List of stages for jobs with their order of execution
   - build
   - test
@@ -13,9 +18,6 @@ stages: # List of stages for jobs with their order of execution
     - bash 
     - eval "$(micromamba shell hook --shell bash)"
     - micromamba activate chimera-sdk-ci
-    - export CMAKE='/usr/sepp/bin/cmake-3.18.1'
-    - export LLVM_INSTALL_PATH='/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0'
-    - export GVSOC_HOME='/scratch/jungvi/chimera-sdk/simulator_install/gvsoc'
 
 build_sdk:
   stage: build
@@ -33,7 +35,7 @@ test:
     matrix:
       - TARGET: [chimera-open]
         TEST: [test_host_returnZero, test_snitchCluster_simpleOffload]
-      - TARGET: [chimera-host, chimera-convolve]
+      - TARGET: [chimera-host]
         TEST: [test_host_returnZero]
   script:
     - !reference [.setup, script]

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -31,8 +31,10 @@ test:
   stage: test
   parallel:
     matrix:
-      - TARGET: [chimera-open, chimera-host, chimera-convolve]
+      - TARGET: [chimera-open, chimera-convolve]
         TEST: [test_host_returnZero, test_snitchCluster_simpleOffload]
+      - TARGET: [chimera-host]
+        TEST: [test_host_returnZero]
   script:
     - !reference [.setup, script]
     - $CMAKE -DTARGET_PLATFORM=$TARGET -DTOOLCHAIN_DIR=$LLVM_INSTALL_PATH -B build
@@ -40,4 +42,4 @@ test:
     - cd ${GVSOC_HOME}
     - echo $CI_PROJECT_DIR
     - echo $CI_PROJECT_PATH
-    - ./install/bin/gvsoc --target=chimera --binary $CI_PROJECT_DIR/build/bin/$TEST image run
+    - ./install/bin/gvsoc --target=chimera --binary $CI_PROJECT_DIR/build/bin/$TEST run

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -31,11 +31,11 @@ test:
   stage: test
   parallel:
     matrix:
-      - TARGET: [chimera-open, chimera-convolve]
+      - TARGET: [chimera-open]
         TEST: [test_host_returnZero, test_snitchCluster_simpleOffload]
-      - TARGET: [chimera-host]
+      - TARGET: [chimera-host, chimera-convolve]
         TEST: [test_host_returnZero]
-  resource_group: gvsoc_test_jobs_group
+  # resource_group: gvsoc_test_jobs_group
   script:
     - !reference [.setup, script]
     - $CMAKE -DTARGET_PLATFORM=$TARGET -DTOOLCHAIN_DIR=$LLVM_INSTALL_PATH -B build

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -11,7 +11,7 @@ stages: # List of stages for jobs with their order of execution
 .setup:
   script:
     - bash 
-    - ./scratch/jungvi/Chimera-sdk-ci/mamba_setup.sh
+    - /scratch/jungvi/Chimera-sdk-ci/mamba_setup.sh
     - mamba activate chimera-sdk-ci
     - export CMAKE='/usr/sepp/bin/cmake-3.18.1'
     - export LLVM_INSTALL_PATH='/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0'

--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -35,11 +35,10 @@ test:
         TEST: [test_host_returnZero, test_snitchCluster_simpleOffload]
       - TARGET: [chimera-host]
         TEST: [test_host_returnZero]
+  resource_group: gvsoc_test_jobs_group
   script:
     - !reference [.setup, script]
     - $CMAKE -DTARGET_PLATFORM=$TARGET -DTOOLCHAIN_DIR=$LLVM_INSTALL_PATH -B build
     - $CMAKE --build build -j
     - cd ${GVSOC_HOME}
-    - echo $CI_PROJECT_DIR
-    - echo $CI_PROJECT_PATH
     - ./install/bin/gvsoc --target=chimera --binary $CI_PROJECT_DIR/build/bin/$TEST run

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,16 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# Author: Philip Wiese <wiesep@iis.ee.ethz.ch>
+# Authors: 
+# - Philip Wiese <wiesep@iis.ee.ethz.ch>
+# - Victor Jung <jungvi@iis.ee.ethz.ch>
+
+ROOT_DIR := $(patsubst %/,%, $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+
+INSTALL_PREFIX ?= simulator_install
+
+GVSOC_INSTALL_DIR ?= ${ROOT_DIR}/${INSTALL_PREFIX}
+GVSOC_COMMIT_HASH ?= ffba6ded9abf0a2c86d0b4096ec20a4392af96ad
 
 CLANG_FORMAT_EXECUTABLE ?= clang-format
 
@@ -10,6 +19,8 @@ help:
 	@echo "Usage: make <target>"
 	@echo ""
 	@echo "Available Targets:"
+	@echo " - gvsoc: Install GVSoC @ ${GVSOC_INSTALL_DIR}"
+	@echo " - export-symbols: Print the list of symbols to export to run the SDK's tests"
 	@echo " - format: Format all code"
 
 format:
@@ -17,4 +28,17 @@ format:
 	@python scripts/run_clang_format.py -ir tests/ hal/ targets/ drivers/ devices/ --clang-format-executable=$(CLANG_FORMAT_EXECUTABLE)
 	@python -m yapf -rip .
 
-.PHONY: format help
+export-symbols:
+	@echo "Please export the following symbols:"
+	@echo "GVSOC_HOME=${GVSOC_INSTALL_DIR}/gvsoc"
+
+gvsoc:
+	mkdir -p ${GVSOC_INSTALL_DIR} && cd ${GVSOC_INSTALL_DIR} && \
+	git clone git@github.com:gvsoc/gvsoc.git && \
+	cd ${GVSOC_INSTALL_DIR}/gvsoc && git checkout ${GVSOC_COMMIT_HASH} && \
+	git submodule update --init --recursive && \
+	pip install -r core/requirements.txt && \
+	pip install -r gapy/requirements.txt && \
+	CXX=g++-11.2.0 CC=gcc-11.2.0 CMAKE=cmake-3.18.1 make all TARGETS=chimera
+
+.PHONY: format help export-symbols gvsoc

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 
 ROOT_DIR := $(patsubst %/,%, $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 
-INSTALL_PREFIX ?= simulator_install
+INSTALL_PREFIX ?= install
 
 GVSOC_INSTALL_DIR ?= ${ROOT_DIR}/${INSTALL_PREFIX}
 GVSOC_COMMIT_HASH ?= ffba6ded9abf0a2c86d0b4096ec20a4392af96ad

--- a/docs/src_sphinx/index.rst
+++ b/docs/src_sphinx/index.rst
@@ -15,6 +15,7 @@ Chimera SDK Documentation
    /usage/usage
    /usage/structure
    /usage/build
+   /usage/ci
 
 .. toctree::
    :maxdepth: 2

--- a/docs/src_sphinx/usage/ci.rst
+++ b/docs/src_sphinx/usage/ci.rst
@@ -1,0 +1,9 @@
+CI System
+=========
+
+The Chimera SDK continously test that all targets can be built and run some test on [GVSoC](https://github.com/gvsoc/gvsoc/) (and RTL in a the close future). Passing the CI is required for your PR to be merged.
+
+
+Collaboration Procedure with Externals
+--------------------------------------
+We run the CI on our internal servers through GitLab, hence the CI is not accessible by external contributor. This means that if you contribute to the SDK, we will run the CI on request and once a PR has been opened.

--- a/docs/src_sphinx/usage/ci.rst
+++ b/docs/src_sphinx/usage/ci.rst
@@ -1,9 +1,8 @@
 CI System
 =========
-
-The Chimera SDK continously test that all targets can be built and run some test on [GVSoC](https://github.com/gvsoc/gvsoc/) (and RTL in a the close future). Passing the CI is required for your PR to be merged.
+The Chimera SDK continuously tests that all targets can be built and runs some tests on [GVSoC](https://github.com/gvsoc/gvsoc/) (and RTL in the near future). Passing the CI is required for your PR to be merged.
 
 
 Collaboration Procedure with Externals
 --------------------------------------
-We run the CI on our internal servers through GitLab, hence the CI is not accessible by external contributor. This means that if you contribute to the SDK, we will run the CI on request and once a PR has been opened.
+We run the CI on our internal servers through GitLab. Hence, the CI is not accessible to external contributors. This means that if you contribute to the SDK, we will run the CI on request and once a PR has been opened.

--- a/docs/src_sphinx/usage/usage.rst
+++ b/docs/src_sphinx/usage/usage.rst
@@ -52,6 +52,16 @@ The SDK supports multiple targets, each with a different configuration. The avai
 - ``chimera-host``: Target with a single host core without clusters.
 - ``chimera-open``: Default target with multiple clusters.
 
+Tests
+-----
+You can test the functional correctness of your code with the event-based simulator [GVSoC](https://github.com/gvsoc/gvsoc/). To install GVSoC, run:
+.. code-block:: bash
+    make gvsoc
+By default this Makefile will install GVSoC in the ``install/gvsoc`` folder. If you want to change the install location you can define the ``GVSOC_INSTALL_DIR`` symbol pointing as the desired install location.
+
+Finally you can execute the tests by running the following command from GVSoC's root:
+.. code-block:: bash
+    ./install/bin/gvsoc --target=chimera --binary <path-to-binary> run
 
 Visual Studio Code Integration
 ------------------------------

--- a/docs/src_sphinx/usage/usage.rst
+++ b/docs/src_sphinx/usage/usage.rst
@@ -55,11 +55,14 @@ The SDK supports multiple targets, each with a different configuration. The avai
 Tests
 -----
 You can test the functional correctness of your code with the event-based simulator [GVSoC](https://github.com/gvsoc/gvsoc/). To install GVSoC, run:
-.. code-block:: bash
-    make gvsoc
-By default this Makefile will install GVSoC in the ``install/gvsoc`` folder. If you want to change the install location you can define the ``GVSOC_INSTALL_DIR`` symbol pointing as the desired install location.
 
-Finally you can execute the tests by running the following command from GVSoC's root:
+.. code-block:: bash
+
+    make gvsoc
+
+By default, this Makefile will install GVSoC in the ``install/gvsoc`` folder. If you want to change the install location, you can define the ``GVSOC_INSTALL_DIR`` symbol pointing at the desired install location.
+
+Finally, you can execute the tests by running the following command from GVSoC's root:
 .. code-block:: bash
     ./install/bin/gvsoc --target=chimera --binary <path-to-binary> run
 

--- a/scripts/run_clang_format.py
+++ b/scripts/run_clang_format.py
@@ -124,14 +124,12 @@ def make_diff(file, original, reformatted):
 
 
 class DiffError(Exception):
-
     def __init__(self, message, errs=None):
         super(DiffError, self).__init__(message)
         self.errs = errs or []
 
 
 class UnexpectedError(Exception):
-
     def __init__(self, message, exc=None):
         super(UnexpectedError, self).__init__(message)
         self.formatted_traceback = traceback.format_exc()
@@ -227,7 +225,6 @@ def bold_red(s):
 
 
 def colorize(diff_lines):
-
     def bold(s):
         return '\x1b[1m' + s + '\x1b[0m'
 

--- a/scripts/run_clang_format.py
+++ b/scripts/run_clang_format.py
@@ -124,12 +124,14 @@ def make_diff(file, original, reformatted):
 
 
 class DiffError(Exception):
+
     def __init__(self, message, errs=None):
         super(DiffError, self).__init__(message)
         self.errs = errs or []
 
 
 class UnexpectedError(Exception):
+
     def __init__(self, message, exc=None):
         super(UnexpectedError, self).__init__(message)
         self.formatted_traceback = traceback.format_exc()
@@ -225,6 +227,7 @@ def bold_red(s):
 
 
 def colorize(diff_lines):
+
     def bold(s):
         return '\x1b[1m' + s + '\x1b[0m'
 


### PR DESCRIPTION
# Changelog
This PR adds CI flow through GitLab for GVSoC tests (and RTL tests in the future).

## Added
- A new Makefile target `gvsoc` to install GVSoC at the location pointed by the GVSOC_INSTALL_DIR symbol. By default, it will be in the `simulator_install` folder.
- A new workflow to trigger the internal Gitlab CI.
- A Gitlab CI building the targets and running the tests with GVSoC.

@Xeratec With GVSoC on the `chimera-convolve` target, the `test_snitchCluster_simpleOffload` test hangs. Is it expected?

## Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
3. [x] The documentation is updated.
4. [x] The GITLAB_CI secret has been added to the target repo.
5. [x] All checks are passing.