### PR TITLE
[tests] Update UART commands to align w/ hardware

### DIFF
--- a/tests/chimera-convolve/host/uartSimple/src_host/test_host.c
+++ b/tests/chimera-convolve/host/uartSimple/src_host/test_host.c
@@ -41,7 +41,7 @@ int main(void) {
     }
 
     // 7. Prepare data to send
-    const char uart_cmd[] = "UartWB";
+    const char uart_cmd[] = "WB";
     size_t cmd_len = sizeof(uart_cmd) - 1;
 
     // 8. Prepare expected response and buffer

--- a/tests/chimera-host/host/uartSimple/src_host/test_host.c
+++ b/tests/chimera-host/host/uartSimple/src_host/test_host.c
@@ -40,7 +40,7 @@ int main(void) {
     }
 
     // 7. Prepare data to send
-    const char uart_cmd[] = "UartWB";
+    const char uart_cmd[] = "WB";
     size_t cmd_len = sizeof(uart_cmd) - 1;
 
     // 8. Prepare expected response and a buffer to read into

--- a/tests/chimera-open/host/uartSimple/src_host/test_host.c
+++ b/tests/chimera-open/host/uartSimple/src_host/test_host.c
@@ -41,7 +41,7 @@ int main(void) {
     }
 
     // 7. Prepare data to send
-    const char uart_cmd[] = "UartWB";
+    const char uart_cmd[] = "WB";
     size_t cmd_len = sizeof(uart_cmd) - 1;
 
     // 8. Prepare expected response and buffer


### PR DESCRIPTION
# Changelog
Align software UART test commands with the new generic two-byte UART command dispatcher implemented in the Chimera HW (tested with https://github.com/pulp-platform/chimera/pull/58).

## Added
- Support for two-byte UART command format in the Chimera-SDK test suite.

## Changed
- Updated `uart_cmd` in the software test from `"UartWB"` to `"WB"`.

## Fixed
- Resolved test failures caused by mismatched UART command length by aligning the SDK tests with the hardware changes from Chimera [PR #58](https://github.com/pulp-platform/chimera/pull/58).

## Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
2. [x] The documentation is updated.
3. [x] All checks are passing.