### PR TITLE
[hotfix] Fix broken CI

### DIFF
--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -5,7 +5,7 @@
 # Author: Victor Jung <jungvi@iis.ee.ethz.ch>
 
 variables:
-  CMAKE: '/usr/sepp/bin/cmake-3.18.1'
+  CMAKE: 'riscv /usr/sepp/bin/cmake-3.28.3'
   LLVM_INSTALL_PATH: '/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0'
   GVSOC_HOME: '/scratch/jungvi/chimera-sdk/install/gvsoc'
 
@@ -15,7 +15,7 @@ stages: # List of stages for jobs with their order of execution
 
 .setup:
   script:
-    - bash 
+    - bash
     - eval "$(micromamba shell hook --shell bash)"
     - micromamba activate chimera-sdk-ci
     - rm -rf build

--- a/docs/src_sphinx/usage/usage.rst
+++ b/docs/src_sphinx/usage/usage.rst
@@ -79,6 +79,7 @@ To enable automatic configuration of the C/C++ extension and support for the int
             "TOOLCHAIN_DIR": "/usr/pack/riscv-1.0-kgf/pulp-llvm-0.12.0",
             "TARGET_PLATFORM": "chimera-convolve",
         },
+        "cmake.cmakePath": "cmake-3.28.3",
     }
 
 If you are not on an IIS system, you need to adjust the paths according to your local installation.


### PR DESCRIPTION
# Changelog
This PR fixes the broken CI.

## Changed
- Switched from cMake 3.18.1 to 3.28.3

## Fixed
- Properly source `riscv` environment

## Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
2. [x] The documentation is updated.
3. [x] All checks are passing.