### PR TITLE
Properly Support Cluster-Local and Cluster-Private Storage

### DIFF
--- a/devices/snitch_cluster/runtime/init.c
+++ b/devices/snitch_cluster/runtime/init.c
@@ -36,16 +36,11 @@ void snrt_init() {
     uintptr_t tls_ptr;
     asm volatile("mv %0, tp" : "=r"(tls_ptr) : :);
 
-    /* __tdata_start/__tdata_end mark the TLS template image (LMA) stored in
-     * memisl. Sizes are computed by subtracting addresses as uintptr_t to
-     * avoid signed/unsigned arithmetic surprises. */
     size_t size_tdata = (uintptr_t)__tdata_end - (uintptr_t)__tdata_start;
     memcpy((void *)tls_ptr, (void *)__tdata_start, size_tdata);
 
     // Clear the tbss section
     size_t size_tbss = (uintptr_t)__tbss_end - (uintptr_t)__tbss_start;
-    /* Compute the tbss offset from the TLS template image symbols rather than
-     * assuming .tbss follows .tdata with no inter-section padding. */
     uintptr_t tbss_off = (uintptr_t)__tbss_start - (uintptr_t)__tdata_start;
     memset((void *)(tls_ptr + tbss_off), 0, size_tbss);
 

--- a/devices/snitch_cluster/runtime/init.c
+++ b/devices/snitch_cluster/runtime/init.c
@@ -10,36 +10,52 @@
 #include "snrt.h"
 
 void snrt_init() {
-    extern volatile uint32_t __tbss_start, __tbss_end, __tdata_start, __tdata_end;
+    /* Linker script symbols: declare as extern char[] and use the symbol
+     * address directly (i.e. __sym, not &__sym). Never declare them as
+     * object types (e.g. volatile uint32_t) — the linker only provides
+     * an address token, not actual storage. */
+    extern char __tbss_start[], __tbss_end[], __tdata_start[], __tdata_end[];
 
-    extern volatile uint32_t __base_l1_alias;
+    extern char __base_l1_alias[];
 
-    extern volatile uint32_t __cbss_start, __cbss_end, __cdata_start, __cdata_end;
-    extern volatile uint32_t __cdata_lma_start, __cdata_lma_end, __cbss_lma_start, __cbss_lma_end;
+    extern char __cbss_start[], __cbss_end[], __cdata_start[], __cdata_end[];
+    extern char __cdata_lma_start[], __cdata_lma_end[];
+    /* __cbss_lma_start/__cbss_lma_end are metadata-only: the .cbss section
+     * is NOLOAD, so no bytes exist at the LMA. The runtime must never use
+     * these as a DMA source — zero-init is performed via the hardware
+     * zero-memory region instead. */
+    extern char __cbss_lma_start[], __cbss_lma_end[];
 
-    extern volatile uint32_t __l1_c0_heap_start, __l1_c1_heap_start, __l1_c2_heap_start,
-        __l1_c3_heap_start, __l1_c4_heap_start;
-    extern volatile uint32_t __l3_heap_start, __l3_heap_end;
+    /* __l3_heap_start/__l3_heap_end are linker-defined address tokens for
+     * the L3 heap region. L1 cluster heap starts are accessed via
+     * _chimera_clusterHeapStart[] from soc_addr_map.h. */
+    extern char __l3_heap_start[], __l3_heap_end[];
 
     /********** Thread Local Storage Initialization **********/
-    volatile uint32_t tls_ptr;
+    /* Store tp as uintptr_t to avoid truncation on wider address models. */
+    uintptr_t tls_ptr;
     asm volatile("mv %0, tp" : "=r"(tls_ptr) : :);
 
-    // Preload the tbss section
-    size_t size_tdata = (size_t)(&__tdata_end) - (size_t)(&__tdata_start);
-    memcpy((void *)tls_ptr, (void *)(&__tdata_start), size_tdata);
+    /* __tdata_start/__tdata_end mark the TLS template image (LMA) stored in
+     * memisl. Sizes are computed by subtracting addresses as uintptr_t to
+     * avoid signed/unsigned arithmetic surprises. */
+    size_t size_tdata = (uintptr_t)__tdata_end - (uintptr_t)__tdata_start;
+    memcpy((void *)tls_ptr, (void *)__tdata_start, size_tdata);
 
     // Clear the tbss section
-    size_t size_tbss = (size_t)(&__tbss_end) - (size_t)(&__tbss_start);
-    memset((void *)(tls_ptr + size_tdata), 0, size_tbss);
+    size_t size_tbss = (uintptr_t)__tbss_end - (uintptr_t)__tbss_start;
+    /* Compute the tbss offset from the TLS template image symbols rather than
+     * assuming .tbss follows .tdata with no inter-section padding. */
+    uintptr_t tbss_off = (uintptr_t)__tbss_start - (uintptr_t)__tdata_start;
+    memset((void *)(tls_ptr + tbss_off), 0, size_tbss);
 
     /********** Cluster Initialization **********/
     if (snrt_is_dm_core()) {
         uint32_t cluster_idx = snrt_cluster_idx();
 
         // Preload l1 data from LMA to VMA
-        uint32_t __l1_lma_start = _chimera_clusterL1LmaStart[cluster_idx];
-        uint32_t __l1_lma_end = _chimera_clusterL1LmaEnd[cluster_idx];
+        uintptr_t __l1_lma_start = _chimera_clusterL1LmaStart[cluster_idx];
+        uintptr_t __l1_lma_end = _chimera_clusterL1LmaEnd[cluster_idx];
 
         size_t size_l1 = __l1_lma_end - __l1_lma_start;
         if (size_l1) {
@@ -48,28 +64,32 @@ void snrt_init() {
         }
 
         // Preload cdata section from LMA to VMA
-        size_t size_cdata = (size_t)(&__cdata_end) - (size_t)(&__cdata_start);
+        size_t size_cdata = (uintptr_t)__cdata_end - (uintptr_t)__cdata_start;
 
-        // Calculate the start address in L1 in gloabal address space
-        uint32_t __cdata_local_start = (uint32_t)&__cdata_start - (uint32_t)&__base_l1_alias +
-                                       _chimera_clusterBase[cluster_idx];
+        // Translate the CLS alias address to the physical L1 address of this cluster
+        uintptr_t __cdata_local_start = (uintptr_t)__cdata_start - (uintptr_t)__base_l1_alias +
+                                        (uintptr_t)_chimera_clusterBase[cluster_idx];
         if (size_cdata) {
-            snrt_dma_start_1d((void *)__cdata_local_start, (void *)(&__cdata_lma_start),
-                              size_cdata);
+            snrt_dma_start_1d((void *)__cdata_local_start, (void *)__cdata_lma_start, size_cdata);
         }
 
         // Clear the cbss section
-        size_t size_cbss = (size_t)(&__cbss_end) - (size_t)(&__cbss_start);
-        // Calculate the start address in L1 in global address space
-        uint32_t __cbss_local_start = (uint32_t)&__cbss_start - (uint32_t)&__base_l1_alias +
-                                      _chimera_clusterBase[cluster_idx];
+        size_t size_cbss = (uintptr_t)__cbss_end - (uintptr_t)__cbss_start;
+        // Translate the CLS alias address to the physical L1 address of this cluster
+        uintptr_t __cbss_local_start = (uintptr_t)__cbss_start - (uintptr_t)__base_l1_alias +
+                                       (uintptr_t)_chimera_clusterBase[cluster_idx];
         if (size_cbss) {
-            snrt_dma_start_1d((void *)__cbss_local_start, (void *)(snrt_zero_memory_ptr()),
+            /* snrt_zero_memory_ptr() returns the cluster's hardware zero-memory
+             * region — a read-only aperture that always reads as 0. The DMA
+             * uses it as a constant-source "memset" to zero the cluster-local
+             * BSS without CPU involvement, i.e. it does NOT need a zero-filled
+             * source buffer. */
+            snrt_dma_start_1d((void *)__cbss_local_start, (void *)snrt_zero_memory_ptr(),
                               size_cbss);
         }
 
         // Initialize the cluster local storage pointer
-        uint32_t l1_heap_base = _chimera_clusterHeapStart[cluster_idx];
+        uintptr_t l1_heap_base = _chimera_clusterHeapStart[cluster_idx];
         _cls_ptr = (cls_t *)l1_heap_base;
 
         // Initialize the L1 allocator
@@ -77,8 +97,8 @@ void snrt_init() {
         snrt_l1_allocator()->end = snrt_l1_end_addr();
         snrt_l1_allocator()->next = snrt_l1_allocator()->base;
 
-        snrt_l3_allocator()->base = ALIGN_UP((uint32_t)&__l3_heap_start, MIN_CHUNK_SIZE);
-        snrt_l3_allocator()->end = (uint32_t)&__l3_heap_end;
+        snrt_l3_allocator()->base = ALIGN_UP((uintptr_t)__l3_heap_start, MIN_CHUNK_SIZE);
+        snrt_l3_allocator()->end = (uintptr_t)__l3_heap_end;
         snrt_l3_allocator()->next = snrt_l3_allocator()->base;
 
         snrt_dma_wait_all();
@@ -87,22 +107,24 @@ void snrt_init() {
         snrt_printf_init();
 
 #ifdef TRACE
-        printf("Size of .tdata : %6d bytes (LMA %p - %p, VMA %p - %p)\n", size_tdata,
-               &__tdata_start, &__tdata_end, tls_ptr, tls_ptr + size_tdata);
-        printf("Size of .tbss  : %6d bytes (LMA %p - %p, VMA %p - %p)\n", size_tbss, &__tbss_start,
-               &__tbss_end, tls_ptr + size_tdata, tls_ptr + size_tdata + size_tbss);
-        printf("Size of .l1    : %6d bytes (LMA %p - %p, VMA %p - %p)\n", size_l1,
+        printf("Size of .tdata : %6zu bytes (LMA %p - %p, VMA %p - %p)\n", size_tdata,
+               (void *)__tdata_start, (void *)__tdata_end, (void *)tls_ptr,
+               (void *)(tls_ptr + size_tdata));
+        printf("Size of .tbss  : %6zu bytes (LMA %p - %p, VMA %p - %p)\n", size_tbss,
+               (void *)__tbss_start, (void *)__tbss_end, (void *)(tls_ptr + tbss_off),
+               (void *)(tls_ptr + tbss_off + size_tbss));
+        printf("Size of .l1    : %6zu bytes (LMA %p - %p, VMA %p - %p)\n", size_l1,
                (void *)__l1_lma_start, (void *)__l1_lma_end,
                (void *)_chimera_clusterL1Start[cluster_idx],
                (void *)_chimera_clusterL1End[cluster_idx]);
-        printf("Size of .cdata : %6d bytes (LMA %p - %p, VMA %p - %p, aliased at %p - %p)\n",
-               size_cdata, (void *)&__cdata_lma_start, (void *)&__cdata_lma_end,
-               (void *)__cdata_local_start, (void *)__cdata_local_start + size_cdata,
-               &__cdata_start, &__cdata_end);
-        printf("Size of .cbss  : %6d bytes (LMA %p - %p, VMA %p - %p, aliased at %p - %p)\n",
-               size_cbss, (void *)&__cbss_lma_start, (void *)&__cbss_lma_end,
-               (void *)__cbss_local_start, (void *)__cbss_local_start + size_cbss, &__cbss_start,
-               &__cbss_end);
+        printf("Size of .cdata : %6zu bytes (LMA %p - %p, VMA %p - %p, aliased at %p - %p)\n",
+               size_cdata, (void *)__cdata_lma_start, (void *)__cdata_lma_end,
+               (void *)__cdata_local_start, (void *)(__cdata_local_start + size_cdata),
+               (void *)__cdata_start, (void *)__cdata_end);
+        printf("Size of .cbss  : %6zu bytes (LMA %p - %p, VMA %p - %p, aliased at %p - %p)\n",
+               size_cbss, (void *)__cbss_lma_start, (void *)__cbss_lma_end,
+               (void *)__cbss_local_start, (void *)(__cbss_local_start + size_cbss),
+               (void *)__cbss_start, (void *)__cbss_end);
 
         printf("L1 Allocator @ %p:\n", snrt_l1_allocator());
         printf("  base @ %p = %#x\n", &snrt_l1_allocator()->base, snrt_l1_allocator()->base);

--- a/devices/snitch_cluster/runtime/init.c
+++ b/devices/snitch_cluster/runtime/init.c
@@ -10,25 +10,16 @@
 #include "snrt.h"
 
 void snrt_init() {
-    extern char __tbss_start, __tbss_end, __tdata_start, __tdata_end;
+    extern volatile uint32_t __tbss_start, __tbss_end, __tdata_start, __tdata_end;
+
+    extern volatile uint32_t __base_l1_alias;
+
     extern volatile uint32_t __cbss_start, __cbss_end, __cdata_start, __cdata_end;
-    extern volatile uint32_t __cdata_lma_start, __cdata_lma_end;
-    extern char __l1_c4_start, __l1_c4_end;
-    extern uint32_t __l3_heap_start, __l3_heap_end;
+    extern volatile uint32_t __cdata_lma_start, __cdata_lma_end, __cbss_lma_start, __cbss_lma_end;
 
-    /********** Cluster Memory Initialization **********/
-    if (snrt_is_dm_core()) {
-        // Preload cdata section from LMA to VMA
-        size_t size = (size_t)(&__cdata_end) - (size_t)(&__cdata_start);
-        // memcpy((void *)(&__cdata_start), (void *)(&__cdata_lma_start), size);
-        snrt_dma_start_1d((void *)(&__cdata_start), (void *)(&__cdata_lma_start), size);
-
-        // Clear the cbss section
-        size = (size_t)(&__cbss_end) - (size_t)(&__cbss_start);
-        // memset((void *)(&__cbss_start), 0, size);
-        snrt_dma_start_1d((void *)(&__cbss_start), (void *)(snrt_zero_memory_ptr()), size);
-        snrt_dma_wait_all();
-    }
+    extern volatile uint32_t __l1_c0_heap_start, __l1_c1_heap_start, __l1_c2_heap_start,
+        __l1_c3_heap_start, __l1_c4_heap_start;
+    extern volatile uint32_t __l3_heap_start, __l3_heap_end;
 
     /********** Thread Local Storage Initialization **********/
     volatile uint32_t tls_ptr;
@@ -37,22 +28,52 @@ void snrt_init() {
     // Preload the tbss section
     size_t size_tdata = (size_t)(&__tdata_end) - (size_t)(&__tdata_start);
     memcpy((void *)tls_ptr, (void *)(&__tdata_start), size_tdata);
-    // snrt_dma_start_1d((void *)tls_ptr, (void *)(&__tdata_start), size_tdata);
 
     // Clear the tbss section
     size_t size_tbss = (size_t)(&__tbss_end) - (size_t)(&__tbss_start);
     memset((void *)(tls_ptr + size_tdata), 0, size_tbss);
-    // snrt_dma_start_1d((void *)(tls_ptr + (size_t)(&__tbss_start) - (size_t)(&__tdata_start)),
-    //   (void *)(snrt_zero_memory_ptr()), size_tdata);
-    // snrt_dma_wait_all();
 
     /********** Cluster Initialization **********/
     if (snrt_is_dm_core()) {
+        uint32_t cluster_idx = snrt_cluster_idx();
+
+        // Preload l1 data from LMA to VMA
+        uint32_t __l1_lma_start = _chimera_clusterL1LmaStart[cluster_idx];
+        uint32_t __l1_lma_end = _chimera_clusterL1LmaEnd[cluster_idx];
+
+        size_t size_l1 = __l1_lma_end - __l1_lma_start;
+        if (size_l1) {
+            snrt_dma_start_1d((void *)_chimera_clusterL1Start[cluster_idx], (void *)__l1_lma_start,
+                              size_l1);
+        }
+
+        // Preload cdata section from LMA to VMA
+        size_t size_cdata = (size_t)(&__cdata_end) - (size_t)(&__cdata_start);
+
+        // Calculate the start address in L1 in gloabal address space
+        uint32_t __cdata_local_start = (uint32_t)&__cdata_start - (uint32_t)&__base_l1_alias +
+                                       _chimera_clusterBase[cluster_idx];
+        if (size_cdata) {
+            snrt_dma_start_1d((void *)__cdata_local_start, (void *)(&__cdata_lma_start),
+                              size_cdata);
+        }
+
+        // Clear the cbss section
+        size_t size_cbss = (size_t)(&__cbss_end) - (size_t)(&__cbss_start);
+        // Calculate the start address in L1 in global address space
+        uint32_t __cbss_local_start = (uint32_t)&__cbss_start - (uint32_t)&__base_l1_alias +
+                                      _chimera_clusterBase[cluster_idx];
+        if (size_cbss) {
+            snrt_dma_start_1d((void *)__cbss_local_start, (void *)(snrt_zero_memory_ptr()),
+                              size_cbss);
+        }
+
         // Initialize the cluster local storage pointer
-        _cls_ptr = (cls_t *)&__l1_c4_start;
+        uint32_t l1_heap_base = _chimera_clusterHeapStart[cluster_idx];
+        _cls_ptr = (cls_t *)l1_heap_base;
 
         // Initialize the L1 allocator
-        snrt_l1_allocator()->base = ALIGN_UP((uint32_t)&__l1_c4_start, MIN_CHUNK_SIZE);
+        snrt_l1_allocator()->base = ALIGN_UP(l1_heap_base + sizeof(cls_t), MIN_CHUNK_SIZE);
         snrt_l1_allocator()->end = snrt_l1_end_addr();
         snrt_l1_allocator()->next = snrt_l1_allocator()->base;
 
@@ -60,8 +81,41 @@ void snrt_init() {
         snrt_l3_allocator()->end = (uint32_t)&__l3_heap_end;
         snrt_l3_allocator()->next = snrt_l3_allocator()->base;
 
+        snrt_dma_wait_all();
+
         // Initialize the printf mutex
         snrt_printf_init();
+
+#ifdef TRACE
+        printf("Size of .tdata : %6d bytes (LMA %p - %p, VMA %p - %p)\n", size_tdata,
+               &__tdata_start, &__tdata_end, tls_ptr, tls_ptr + size_tdata);
+        printf("Size of .tbss  : %6d bytes (LMA %p - %p, VMA %p - %p)\n", size_tbss, &__tbss_start,
+               &__tbss_end, tls_ptr + size_tdata, tls_ptr + size_tdata + size_tbss);
+        printf("Size of .l1    : %6d bytes (LMA %p - %p, VMA %p - %p)\n", size_l1,
+               (void *)__l1_lma_start, (void *)__l1_lma_end,
+               (void *)_chimera_clusterL1Start[cluster_idx],
+               (void *)_chimera_clusterL1End[cluster_idx]);
+        printf("Size of .cdata : %6d bytes (LMA %p - %p, VMA %p - %p, aliased at %p - %p)\n",
+               size_cdata, (void *)&__cdata_lma_start, (void *)&__cdata_lma_end,
+               (void *)__cdata_local_start, (void *)__cdata_local_start + size_cdata,
+               &__cdata_start, &__cdata_end);
+        printf("Size of .cbss  : %6d bytes (LMA %p - %p, VMA %p - %p, aliased at %p - %p)\n",
+               size_cbss, (void *)&__cbss_lma_start, (void *)&__cbss_lma_end,
+               (void *)__cbss_local_start, (void *)__cbss_local_start + size_cbss, &__cbss_start,
+               &__cbss_end);
+
+        printf("L1 Allocator @ %p:\n", snrt_l1_allocator());
+        printf("  base @ %p = %#x\n", &snrt_l1_allocator()->base, snrt_l1_allocator()->base);
+        printf("  end  @ %p = %#x\n", &snrt_l1_allocator()->end, snrt_l1_allocator()->end);
+        printf("  next @ %p = %#x\n", &snrt_l1_allocator()->next, snrt_l1_allocator()->next);
+
+        printf("L3 Allocator @ %p:\n", snrt_l3_allocator());
+        printf("  base @ %p = %#x\n", &snrt_l3_allocator()->base, snrt_l3_allocator()->base);
+        printf("  end  @ %p = %#x\n", &snrt_l3_allocator()->end, snrt_l3_allocator()->end);
+        printf("  next @ %p = %#x\n", &snrt_l3_allocator()->next, snrt_l3_allocator()->next);
+
+        printf("Cluster Local Storage @ %p = %#x\n", &_cls_ptr, cls());
+#endif
     }
 
     snrt_cluster_hw_barrier();

--- a/devices/snitch_cluster/runtime/snrt.h
+++ b/devices/snitch_cluster/runtime/snrt.h
@@ -23,6 +23,7 @@ int snrt_printf(const char *fmt, ...);
 #define printf snrt_printf_log
 
 #include "config.h"
+#include "util.h"
 
 // Forward declarations
 #include "alloc_decls.h"
@@ -55,3 +56,27 @@ int snrt_printf(const char *fmt, ...);
 #include "team.h"
 #include "types.h"
 #include "start.h"
+
+// Utility macros
+/**
+ * Places a zero-initialized declaration into the L1 memory of each cluster.
+ * Every cluster receives its own copy.
+ */
+#if defined(__clang__)
+#define SNRT_CLUSTER_L1_ZERO(decl) \
+    _Pragma("clang section bss = \".cbss\"") decl; \
+    _Pragma("clang section bss = \"\"")
+#else
+#define SNRT_CLUSTER_L1_ZERO(decl) decl __attribute__((section(".cbss,\"aw\",@nobits#")))
+#endif
+
+/**
+ * Places an initialized declaration into the L1 memory of each cluster.
+ * Each cluster receives its own copy.
+ */
+#define SNRT_CLUSTER_L1_COPY(decl) decl __attribute__((section(".cdata")))
+
+/**
+ * Places a initialized declaration into the L1 memory of a specific cluster.
+ */
+#define SNRT_CLUSTER_L1(decl, cluster_id) decl __attribute__((section(".l1_c" #cluster_id)))

--- a/devices/snitch_cluster/runtime/util.h
+++ b/devices/snitch_cluster/runtime/util.h
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: 2022 ETH Zurich and University of Bologna
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Include Standard Libraries
+#include <stdint.h>
+
+// Include Target Specific Headers
+
+// Include Driver Headers
+
+// Include Runtime Headers
+
+/** @name Register Access Helpers
+ *  @brief Functions for reading/writing memory-mapped registers.
+ *  @{
+ */
+
+/**
+ * @brief Gets a pointer to an 8-bit register.
+ * @param base Base address of the register.
+ * @param offset Register offset.
+ * @return Pointer to the 8-bit register.
+ */
+static inline volatile uint8_t *reg8(uint32_t base, int offset) {
+    return (volatile uint8_t *)(uintptr_t)(base + offset);
+}
+
+/**
+ * @brief Writes a value to an 8-bit register.
+ * @param base Base address of the register.
+ * @param offset Register offset.
+ * @param val Value to write.
+ */
+static inline void reg8_write(uint32_t base, int offset, uint8_t val) {
+    *reg8(base, offset) = val;
+}
+
+/**
+ * @brief Reads a value from an 8-bit register.
+ * @param base Base address of the register.
+ * @param offset Register offset.
+ * @return Value read from the register.
+ */
+static inline uint8_t reg8_read(uint32_t base, int offset) {
+    return *reg8(base, offset);
+}
+
+/**
+ * @brief Gets a pointer to a 32-bit register.
+ * @param base Base address of the register.
+ * @param offs Register offset.
+ * @return Pointer to the 32-bit register.
+ */
+static inline volatile uint32_t *reg32(void *base, int offs) {
+    return (volatile uint32_t *)(base + offs);
+}
+
+/** @} */
+
+/** @name Memory and Execution Fencing
+ *  @brief Functions to enforce memory ordering and instruction synchronization.
+ *  @{
+ */
+
+/**
+ * @brief Issues a memory fence to enforce ordering of memory accesses.
+ */
+static inline void fence() {
+    asm volatile("fence" ::: "memory");
+}
+
+/**
+ * @brief Issues an instruction fence to synchronize instruction fetches.
+ */
+static inline void fencei() {
+    asm volatile("fence.i" ::: "memory");
+}
+
+/**
+ * @brief Issues a wait-for-interrupt (WFI) instruction to enter low-power mode.
+ */
+static inline void wfi() {
+    asm volatile("wfi" ::: "memory");
+}
+
+/** @} */
+
+/** @name Interrupt Control
+ *  @brief Functions to enable or disable interrupts.
+ *  @{
+ */
+
+/**
+ * @brief Enables or disables M-mode timer interrupts.
+ * @param enable Set to 1 to enable, 0 to disable.
+ */
+static inline void set_mtie(int enable) {
+    if (enable)
+        asm volatile("csrs mie, %0" ::"r"(128) : "memory");
+    else
+        asm volatile("csrc mie, %0" ::"r"(128) : "memory");
+}
+
+/**
+ * @brief Enables or disables M-mode global interrupts.
+ * @param enable Set to 1 to enable, 0 to disable.
+ */
+static inline void set_mie(int enable) {
+    if (enable)
+        asm volatile("csrsi mstatus, 8" ::: "memory");
+    else
+        asm volatile("csrci mstatus, 8" ::: "memory");
+}
+
+/** @} */
+
+/** @name Cycle Counter
+ *  @brief Functions to retrieve system cycle count.
+ *  @{
+ */
+
+/**
+ * @brief Gets the number of cycles since system reset.
+ * @return 32-bit cycle count.
+ */
+static inline uint32_t get_mcycle() {
+    uint32_t mcycle;
+    asm volatile("csrr %0, mcycle" : "=r"(mcycle)::"memory");
+    return mcycle;
+}
+
+/** @} */
+
+/** @name Function Invocation Helpers
+ *  @brief Functions for invoking dynamic function pointers.
+ *  @{
+ */
+
+/**
+ * @brief Invokes a function stored in memory.
+ *
+ * This function may also be used to invoke code that does not return.
+ *
+ * @param code Pointer to the function to invoke.
+ * @return Return value of the invoked function.
+ */
+static inline uint32_t invoke(void *code) {
+    uint32_t (*code_fun_ptr)(void) = code;
+    fencei();
+    return code_fun_ptr();
+}
+
+/**
+ * @brief Sets the global pointer register and returns its previous value.
+ *
+ * @note Use with caution, as modifying the global pointer register (gp)
+ *       can affect program execution.
+ *
+ * @param gp New global pointer value.
+ * @return Previous global pointer value.
+ */
+static inline void *gprw(void *gp) {
+    void *ret;
+    asm volatile("mv %0, gp" : "=r"(ret)::"memory");
+    if (gp) asm volatile("mv gp, %0" ::"r"(gp) : "memory", "gp");
+    return ret;
+}
+
+/** @} */
+
+/** @name Error Handling Macros
+ *  @brief Macros for function return handling.
+ *  @{
+ */
+
+/**
+ * @brief Checks if a function call returns a nonzero value and returns early.
+ *
+ * This macro evaluates the given function call. If the return value is
+ * nonzero, the calling function will return immediately with the same value.
+ *
+ * @param call Function call to check.
+ */
+#define CHECK_CALL(call) \
+    { \
+        int __ccret = (volatile int)(call); \
+        if (__ccret) return __ccret; \
+    }
+
+/**
+ * @brief Asserts a condition and returns an error code if it fails.
+ *
+ * If the condition evaluates to false, the function returns the provided error code.
+ *
+ * @param ret Error code to return.
+ * @param cond Condition to check.
+ */
+#define CHECK_ASSERT(ret, cond) \
+    if (!(cond)) return (ret);
+
+/** @} */

--- a/devices/snitch_cluster/runtime/util.h
+++ b/devices/snitch_cluster/runtime/util.h
@@ -23,8 +23,8 @@
  * @param offset Register offset.
  * @return Pointer to the 8-bit register.
  */
-static inline volatile uint8_t *reg8(uint32_t base, int offset) {
-    return (volatile uint8_t *)(uintptr_t)(base + offset);
+static inline volatile uint8_t *reg8(uintptr_t base, int offset) {
+    return (volatile uint8_t *)((uintptr_t)base + (intptr_t)offset);
 }
 
 /**
@@ -33,7 +33,7 @@ static inline volatile uint8_t *reg8(uint32_t base, int offset) {
  * @param offset Register offset.
  * @param val Value to write.
  */
-static inline void reg8_write(uint32_t base, int offset, uint8_t val) {
+static inline void reg8_write(uintptr_t base, int offset, uint8_t val) {
     *reg8(base, offset) = val;
 }
 
@@ -43,7 +43,7 @@ static inline void reg8_write(uint32_t base, int offset, uint8_t val) {
  * @param offset Register offset.
  * @return Value read from the register.
  */
-static inline uint8_t reg8_read(uint32_t base, int offset) {
+static inline uint8_t reg8_read(uintptr_t base, int offset) {
     return *reg8(base, offset);
 }
 
@@ -54,7 +54,7 @@ static inline uint8_t reg8_read(uint32_t base, int offset) {
  * @return Pointer to the 32-bit register.
  */
 static inline volatile uint32_t *reg32(void *base, int offs) {
-    return (volatile uint32_t *)(base + offs);
+    return (volatile uint32_t *)((uintptr_t)base + (intptr_t)offs);
 }
 
 /** @} */
@@ -122,8 +122,11 @@ static inline void set_mie(int enable) {
  */
 
 /**
- * @brief Gets the number of cycles since system reset.
- * @return 32-bit cycle count.
+ * @brief Gets the lower 32 bits of the cycle counter since system reset.
+ * @return 32-bit cycle count (wraps every ~4 billion cycles).
+ * @note Only the lower 32 bits are returned. If callers rely on monotonic
+ *       time across wrap boundaries, a 64-bit hi/lo read sequence should
+ *       be used instead (read mcycleh, mcycle, mcycleh again to detect carry).
  */
 static inline uint32_t get_mcycle() {
     uint32_t mcycle;

--- a/host/runtime/src/putc.c
+++ b/host/runtime/src/putc.c
@@ -52,7 +52,7 @@ int uart_flush(FILE *file) {
 #elif HARDWARE_BACKEND_RTL
 int uart_putc(char c, FILE *file) {
     (void)c;
-    *(volatile uint32_t *)(long)(0x300010F0) = c;
+    *(volatile uint32_t *)(long)(0x30004FFC) = c;
     return c;
 }
 int uart_getc(FILE *file) {

--- a/targets/chimera-convolve/common.ldh
+++ b/targets/chimera-convolve/common.ldh
@@ -6,7 +6,7 @@
 ENTRY(_start)
 
 MEMORY {
-  l1 (rwx)      : ORIGIN = 0x18000000, LENGTH = 128K
+  l1_alias (rwx): ORIGIN = 0x18000000, LENGTH = 128K
   l1_c0 (rwx)   : ORIGIN = 0x40000000, LENGTH = 128K
   l1_c1 (rwx)   : ORIGIN = 0x40200000, LENGTH = 128K
   l1_c2 (rwx)   : ORIGIN = 0x40400000, LENGTH = 128K
@@ -27,6 +27,8 @@ SECTIONS {
   /* By default, keep the calling context (boot ROM) stack pointer */
   __global_pointer$ = ADDR(.misc) + SIZEOF(.misc) / 2;
   __stack_pointer$  = __stack_start - 8;
+
+  __base_l1_alias = ORIGIN(l1_alias);
 
   /* Further addresses */
   __base_dma      = 0x01000000;

--- a/targets/chimera-convolve/inc/addr_maps/soc_addr_map.h
+++ b/targets/chimera-convolve/inc/addr_maps/soc_addr_map.h
@@ -38,6 +38,8 @@
 
 #define CLUSTER_HART_BASE CLUSTER_0_HART_BASE
 
+#define _chimera_numClusters 5
+
 static const uint8_t _chimera_numCores[] = {CLUSTER_0_NUMCORES, CLUSTER_1_NUMCORES,
                                             CLUSTER_2_NUMCORES, CLUSTER_3_NUMCORES,
                                             CLUSTER_4_NUMCORES};
@@ -45,38 +47,25 @@ static const uint8_t _chimera_hartBase[] = {CLUSTER_0_HART_BASE, CLUSTER_1_HART_
                                             CLUSTER_2_HART_BASE, CLUSTER_3_HART_BASE,
                                             CLUSTER_4_HART_BASE};
 
-static const uint32_t _chimera_clusterBase[] = {CLUSTER_0_BASE, CLUSTER_1_BASE, CLUSTER_2_BASE,
-                                                CLUSTER_3_BASE, CLUSTER_4_BASE};
+extern const uintptr_t _chimera_clusterBase[_chimera_numClusters];
 
-extern volatile uint32_t __l1_c0_heap_start, __l1_c1_heap_start, __l1_c2_heap_start,
-    __l1_c3_heap_start, __l1_c4_heap_start;
-static const uint32_t _chimera_clusterHeapStart[] = {
-    (uint32_t)&__l1_c0_heap_start, (uint32_t)&__l1_c1_heap_start, (uint32_t)&__l1_c2_heap_start,
-    (uint32_t)&__l1_c3_heap_start, (uint32_t)&__l1_c4_heap_start};
+extern char __l1_c0_heap_start[], __l1_c1_heap_start[], __l1_c2_heap_start[], __l1_c3_heap_start[],
+    __l1_c4_heap_start[];
+extern const uintptr_t _chimera_clusterHeapStart[_chimera_numClusters];
 
-extern volatile uint32_t __l1_c0_start, __l1_c1_start, __l1_c2_start, __l1_c3_start, __l1_c4_start;
-static const uint32_t _chimera_clusterL1Start[] = {
-    (uint32_t)&__l1_c0_start, (uint32_t)&__l1_c1_start, (uint32_t)&__l1_c2_start,
-    (uint32_t)&__l1_c3_start, (uint32_t)&__l1_c4_start};
+extern char __l1_c0_start[], __l1_c1_start[], __l1_c2_start[], __l1_c3_start[], __l1_c4_start[];
+extern const uintptr_t _chimera_clusterL1Start[_chimera_numClusters];
 
-extern volatile uint32_t __l1_c0_end, __l1_c1_end, __l1_c2_end, __l1_c3_end, __l1_c4_end;
-static const uint32_t _chimera_clusterL1End[] = {(uint32_t)&__l1_c0_end, (uint32_t)&__l1_c1_end,
-                                                 (uint32_t)&__l1_c2_end, (uint32_t)&__l1_c3_end,
-                                                 (uint32_t)&__l1_c4_end};
+extern char __l1_c0_end[], __l1_c1_end[], __l1_c2_end[], __l1_c3_end[], __l1_c4_end[];
+extern const uintptr_t _chimera_clusterL1End[_chimera_numClusters];
 
-extern volatile uint32_t __l1_c0_lma_start, __l1_c1_lma_start, __l1_c2_lma_start, __l1_c3_lma_start,
-    __l1_c4_lma_start;
-static const uint32_t _chimera_clusterL1LmaStart[] = {
-    (uint32_t)&__l1_c0_lma_start, (uint32_t)&__l1_c1_lma_start, (uint32_t)&__l1_c2_lma_start,
-    (uint32_t)&__l1_c3_lma_start, (uint32_t)&__l1_c4_lma_start};
+extern char __l1_c0_lma_start[], __l1_c1_lma_start[], __l1_c2_lma_start[], __l1_c3_lma_start[],
+    __l1_c4_lma_start[];
+extern const uintptr_t _chimera_clusterL1LmaStart[_chimera_numClusters];
 
-extern volatile uint32_t __l1_c0_lma_end, __l1_c1_lma_end, __l1_c2_lma_end, __l1_c3_lma_end,
-    __l1_c4_lma_end;
-static const uint32_t _chimera_clusterL1LmaEnd[] = {
-    (uint32_t)&__l1_c0_lma_end, (uint32_t)&__l1_c1_lma_end, (uint32_t)&__l1_c2_lma_end,
-    (uint32_t)&__l1_c3_lma_end, (uint32_t)&__l1_c4_lma_end};
-
-#define _chimera_numClusters 5
+extern char __l1_c0_lma_end[], __l1_c1_lma_end[], __l1_c2_lma_end[], __l1_c3_lma_end[],
+    __l1_c4_lma_end[];
+extern const uintptr_t _chimera_clusterL1LmaEnd[_chimera_numClusters];
 
 #ifdef CHIMERA_PADFRAME_BASE_ADDRESS
 #undef CHIMERA_PADFRAME_BASE_ADDRESS

--- a/targets/chimera-convolve/inc/addr_maps/soc_addr_map.h
+++ b/targets/chimera-convolve/inc/addr_maps/soc_addr_map.h
@@ -48,6 +48,34 @@ static const uint8_t _chimera_hartBase[] = {CLUSTER_0_HART_BASE, CLUSTER_1_HART_
 static const uint32_t _chimera_clusterBase[] = {CLUSTER_0_BASE, CLUSTER_1_BASE, CLUSTER_2_BASE,
                                                 CLUSTER_3_BASE, CLUSTER_4_BASE};
 
+extern volatile uint32_t __l1_c0_heap_start, __l1_c1_heap_start, __l1_c2_heap_start,
+    __l1_c3_heap_start, __l1_c4_heap_start;
+static const uint32_t _chimera_clusterHeapStart[] = {
+    (uint32_t)&__l1_c0_heap_start, (uint32_t)&__l1_c1_heap_start, (uint32_t)&__l1_c2_heap_start,
+    (uint32_t)&__l1_c3_heap_start, (uint32_t)&__l1_c4_heap_start};
+
+extern volatile uint32_t __l1_c0_start, __l1_c1_start, __l1_c2_start, __l1_c3_start, __l1_c4_start;
+static const uint32_t _chimera_clusterL1Start[] = {
+    (uint32_t)&__l1_c0_start, (uint32_t)&__l1_c1_start, (uint32_t)&__l1_c2_start,
+    (uint32_t)&__l1_c3_start, (uint32_t)&__l1_c4_start};
+
+extern volatile uint32_t __l1_c0_end, __l1_c1_end, __l1_c2_end, __l1_c3_end, __l1_c4_end;
+static const uint32_t _chimera_clusterL1End[] = {(uint32_t)&__l1_c0_end, (uint32_t)&__l1_c1_end,
+                                                 (uint32_t)&__l1_c2_end, (uint32_t)&__l1_c3_end,
+                                                 (uint32_t)&__l1_c4_end};
+
+extern volatile uint32_t __l1_c0_lma_start, __l1_c1_lma_start, __l1_c2_lma_start, __l1_c3_lma_start,
+    __l1_c4_lma_start;
+static const uint32_t _chimera_clusterL1LmaStart[] = {
+    (uint32_t)&__l1_c0_lma_start, (uint32_t)&__l1_c1_lma_start, (uint32_t)&__l1_c2_lma_start,
+    (uint32_t)&__l1_c3_lma_start, (uint32_t)&__l1_c4_lma_start};
+
+extern volatile uint32_t __l1_c0_lma_end, __l1_c1_lma_end, __l1_c2_lma_end, __l1_c3_lma_end,
+    __l1_c4_lma_end;
+static const uint32_t _chimera_clusterL1LmaEnd[] = {
+    (uint32_t)&__l1_c0_lma_end, (uint32_t)&__l1_c1_lma_end, (uint32_t)&__l1_c2_lma_end,
+    (uint32_t)&__l1_c3_lma_end, (uint32_t)&__l1_c4_lma_end};
+
 #define _chimera_numClusters 5
 
 #ifdef CHIMERA_PADFRAME_BASE_ADDRESS

--- a/targets/chimera-convolve/link.ld
+++ b/targets/chimera-convolve/link.ld
@@ -77,10 +77,14 @@ SECTIONS {
     __cbss_end = .;
   } > l1_alias AT > memisl
 
+  /* NOTE: .cbss is NOLOAD, so no bytes are written to the LMA by the loader.
+   * Zero-init is performed via the hardware zero-memory region
+   * (see snrt_zero_memory_ptr()). */
   __cbss_lma_start = LOADADDR(.cbss);
   __cbss_lma_end = LOADADDR(.cbss) + SIZEOF(.cbss);
 
-  /* Reserve the rest of cluster-local L1 for general allocations. */
+  /* Total cluster-local storage (CLS) reserved at the base of every cluster's
+   * L1 TCDM.  Must not exceed the l1_alias window (= L1 size per cluster). */
   __cls_reserved_size = SIZEOF(.cdata) + SIZEOF(.cbss);
 
   .bulk : ALIGN(16) {
@@ -106,70 +110,82 @@ SECTIONS {
     . += __cls_reserved_size;
   } > l1_c4
 
+  /* Provide LMA symbols for the .l1_cX sections so the runtime DMA init code
+   * can copy cluster-private initialized data from memisl (LMA) to each
+   * cluster's L1 TCDM (VMA).  Two reasons the LMA copy is necessary:
+   *  1. The binary loader places data at the LMA (memisl); the VMA points
+   *     into cluster L1 which is not reachable by the loader.
+   *  2. Some debug probes (JTAG) cannot reliably access cluster L1 during
+   *     early boot, so the DMA copy from memisl is the only safe path.
+   *
+   * LMA symbols are assigned inside the section body so that lld only
+   * evaluates LOADADDR/SIZEOF when the section actually has input sections.
+   * PROVIDE(...= 0) outside gives a safe fallback: the runtime sees
+   * lma_end - lma_start = 0 and skips the DMA for empty sections. */
   .l1_c0 : ALIGN(16) {
     __l1_c0_start = .;
-    *(.l1_c0 .l1_c0.*)
+    __l1_c0_lma_start = LOADADDR(.l1_c0);
+    KEEP(*(.l1_c0 .l1_c0.*))
     __l1_c0_end = .;
+    __l1_c0_lma_end = LOADADDR(.l1_c0) + SIZEOF(.l1_c0);
     . = ALIGN(16);
     __l1_c0_heap_start = .;
     __l1_c0_heap_end = ORIGIN(l1_c0) + LENGTH(l1_c0);
   } > l1_c0 AT > memisl
-
-  /* Provide symbols for the load address (LMA) of the .l1_c0 section so
-     runtime code can copy the initialized contents from flash/main memory
-     instead of using the VMA which points into L1.
-     WIESEP: This is also required as JTAG can somehow not access L1 memory...*/
-  __l1_c0_lma_start = LOADADDR(.l1_c0);
-  __l1_c0_lma_end = LOADADDR(.l1_c0) + SIZEOF(.l1_c0);
+  PROVIDE(__l1_c0_lma_start = 0);
+  PROVIDE(__l1_c0_lma_end = 0);
 
   .l1_c1 : ALIGN(16) {
     __l1_c1_start = .;
-    *(.l1_c1 .l1_c1.*)
+    __l1_c1_lma_start = LOADADDR(.l1_c1);
+    KEEP(*(.l1_c1 .l1_c1.*))
     __l1_c1_end = .;
+    __l1_c1_lma_end = LOADADDR(.l1_c1) + SIZEOF(.l1_c1);
     . = ALIGN(16);
     __l1_c1_heap_start = .;
     __l1_c1_heap_end = ORIGIN(l1_c1) + LENGTH(l1_c1);
   } > l1_c1 AT > memisl
-
-  __l1_c1_lma_start = LOADADDR(.l1_c1);
-  __l1_c1_lma_end = LOADADDR(.l1_c1) + SIZEOF(.l1_c1);
-
+  PROVIDE(__l1_c1_lma_start = 0);
+  PROVIDE(__l1_c1_lma_end = 0);
 
   .l1_c2 : ALIGN(16) {
     __l1_c2_start = .;
-    *(.l1_c2 .l1_c2.*)
+    __l1_c2_lma_start = LOADADDR(.l1_c2);
+    KEEP(*(.l1_c2 .l1_c2.*))
     __l1_c2_end = .;
+    __l1_c2_lma_end = LOADADDR(.l1_c2) + SIZEOF(.l1_c2);
     . = ALIGN(16);
     __l1_c2_heap_start = .;
     __l1_c2_heap_end = ORIGIN(l1_c2) + LENGTH(l1_c2);
   } > l1_c2 AT > memisl
-
-  __l1_c2_lma_start = LOADADDR(.l1_c2);
-  __l1_c2_lma_end = LOADADDR(.l1_c2) + SIZEOF(.l1_c2);
+  PROVIDE(__l1_c2_lma_start = 0);
+  PROVIDE(__l1_c2_lma_end = 0);
 
   .l1_c3 : ALIGN(16) {
     __l1_c3_start = .;
-    *(.l1_c3 .l1_c3.*)
+    __l1_c3_lma_start = LOADADDR(.l1_c3);
+    KEEP(*(.l1_c3 .l1_c3.*))
     __l1_c3_end = .;
+    __l1_c3_lma_end = LOADADDR(.l1_c3) + SIZEOF(.l1_c3);
     . = ALIGN(16);
     __l1_c3_heap_start = .;
     __l1_c3_heap_end = ORIGIN(l1_c3) + LENGTH(l1_c3);
   } > l1_c3 AT > memisl
-
-  __l1_c3_lma_start = LOADADDR(.l1_c3);
-  __l1_c3_lma_end = LOADADDR(.l1_c3) + SIZEOF(.l1_c3);
+  PROVIDE(__l1_c3_lma_start = 0);
+  PROVIDE(__l1_c3_lma_end = 0);
 
   .l1_c4 : ALIGN(16) {
     __l1_c4_start = .;
-    *(.l1_c4 .l1_c4.*)
+    __l1_c4_lma_start = LOADADDR(.l1_c4);
+    KEEP(*(.l1_c4 .l1_c4.*))
     __l1_c4_end = .;
+    __l1_c4_lma_end = LOADADDR(.l1_c4) + SIZEOF(.l1_c4);
     . = ALIGN(16);
     __l1_c4_heap_start = .;
     __l1_c4_heap_end = ORIGIN(l1_c4) + LENGTH(l1_c4);
   } > l1_c4 AT > memisl
-
-  __l1_c4_lma_start = LOADADDR(.l1_c4);
-  __l1_c4_lma_end = LOADADDR(.l1_c4) + SIZEOF(.l1_c4);
+  PROVIDE(__l1_c4_lma_start = 0);
+  PROVIDE(__l1_c4_lma_end = 0);
 
   .l2_heap : ALIGN(16) {
     __l2_heap_start = .;

--- a/targets/chimera-convolve/link.ld
+++ b/targets/chimera-convolve/link.ld
@@ -11,7 +11,7 @@ SECTIONS {
     *(.text.*)
   } > memisl
 
-  .misc : ALIGN(16) {
+  .misc : ALIGN(32) {
     *(.rodata)
     *(.rodata.*)
     *(.data)
@@ -87,26 +87,26 @@ SECTIONS {
    * L1 TCDM.  Must not exceed the l1_alias window (= L1 size per cluster). */
   __cls_reserved_size = SIZEOF(.cdata) + SIZEOF(.cbss);
 
-  .bulk : ALIGN(16) {
+  .bulk : ALIGN(32) {
     *(.bulk)
     *(.bulk.*)
   } > memisl
 
-  .l1_c0_cls  (NOLOAD): ALIGN(16) {
+  .l1_c0_cls  (NOLOAD): ALIGN(32) {
     . += __cls_reserved_size;
   } > l1_c0
 
-  .l1_c1_cls  (NOLOAD): ALIGN(16) {
+  .l1_c1_cls  (NOLOAD): ALIGN(32) {
     . += __cls_reserved_size;
   } > l1_c1
 
-  .l1_c2_cls  (NOLOAD): ALIGN(16) {
+  .l1_c2_cls  (NOLOAD): ALIGN(32) {
     . += __cls_reserved_size;
   } > l1_c2
-  .l1_c3_cls  (NOLOAD): ALIGN(16) {
+  .l1_c3_cls  (NOLOAD): ALIGN(32) {
     . += __cls_reserved_size;
   } > l1_c3
-  .l1_c4_cls  (NOLOAD): ALIGN(16) {
+  .l1_c4_cls  (NOLOAD): ALIGN(32) {
     . += __cls_reserved_size;
   } > l1_c4
 
@@ -122,72 +122,72 @@ SECTIONS {
    * evaluates LOADADDR/SIZEOF when the section actually has input sections.
    * PROVIDE(...= 0) outside gives a safe fallback: the runtime sees
    * lma_end - lma_start = 0 and skips the DMA for empty sections. */
-  .l1_c0 : ALIGN(16) {
+  .l1_c0 : ALIGN(32) {
     __l1_c0_start = .;
     __l1_c0_lma_start = LOADADDR(.l1_c0);
     KEEP(*(.l1_c0 .l1_c0.*))
     __l1_c0_end = .;
     __l1_c0_lma_end = LOADADDR(.l1_c0) + SIZEOF(.l1_c0);
-    . = ALIGN(16);
+    . = ALIGN(32);
     __l1_c0_heap_start = .;
     __l1_c0_heap_end = ORIGIN(l1_c0) + LENGTH(l1_c0);
   } > l1_c0 AT > memisl
   PROVIDE(__l1_c0_lma_start = 0);
   PROVIDE(__l1_c0_lma_end = 0);
 
-  .l1_c1 : ALIGN(16) {
+  .l1_c1 : ALIGN(32) {
     __l1_c1_start = .;
     __l1_c1_lma_start = LOADADDR(.l1_c1);
     KEEP(*(.l1_c1 .l1_c1.*))
     __l1_c1_end = .;
     __l1_c1_lma_end = LOADADDR(.l1_c1) + SIZEOF(.l1_c1);
-    . = ALIGN(16);
+    . = ALIGN(32);
     __l1_c1_heap_start = .;
     __l1_c1_heap_end = ORIGIN(l1_c1) + LENGTH(l1_c1);
   } > l1_c1 AT > memisl
   PROVIDE(__l1_c1_lma_start = 0);
   PROVIDE(__l1_c1_lma_end = 0);
 
-  .l1_c2 : ALIGN(16) {
+  .l1_c2 : ALIGN(32) {
     __l1_c2_start = .;
     __l1_c2_lma_start = LOADADDR(.l1_c2);
     KEEP(*(.l1_c2 .l1_c2.*))
     __l1_c2_end = .;
     __l1_c2_lma_end = LOADADDR(.l1_c2) + SIZEOF(.l1_c2);
-    . = ALIGN(16);
+    . = ALIGN(32);
     __l1_c2_heap_start = .;
     __l1_c2_heap_end = ORIGIN(l1_c2) + LENGTH(l1_c2);
   } > l1_c2 AT > memisl
   PROVIDE(__l1_c2_lma_start = 0);
   PROVIDE(__l1_c2_lma_end = 0);
 
-  .l1_c3 : ALIGN(16) {
+  .l1_c3 : ALIGN(32) {
     __l1_c3_start = .;
     __l1_c3_lma_start = LOADADDR(.l1_c3);
     KEEP(*(.l1_c3 .l1_c3.*))
     __l1_c3_end = .;
     __l1_c3_lma_end = LOADADDR(.l1_c3) + SIZEOF(.l1_c3);
-    . = ALIGN(16);
+    . = ALIGN(32);
     __l1_c3_heap_start = .;
     __l1_c3_heap_end = ORIGIN(l1_c3) + LENGTH(l1_c3);
   } > l1_c3 AT > memisl
   PROVIDE(__l1_c3_lma_start = 0);
   PROVIDE(__l1_c3_lma_end = 0);
 
-  .l1_c4 : ALIGN(16) {
+  .l1_c4 : ALIGN(32) {
     __l1_c4_start = .;
     __l1_c4_lma_start = LOADADDR(.l1_c4);
     KEEP(*(.l1_c4 .l1_c4.*))
     __l1_c4_end = .;
     __l1_c4_lma_end = LOADADDR(.l1_c4) + SIZEOF(.l1_c4);
-    . = ALIGN(16);
+    . = ALIGN(32);
     __l1_c4_heap_start = .;
     __l1_c4_heap_end = ORIGIN(l1_c4) + LENGTH(l1_c4);
   } > l1_c4 AT > memisl
   PROVIDE(__l1_c4_lma_start = 0);
   PROVIDE(__l1_c4_lma_end = 0);
 
-  .l2_heap : ALIGN(16) {
+  .l2_heap : ALIGN(32) {
     __l2_heap_start = .;
     __l2_heap_end = ORIGIN(memisl) + LENGTH(memisl);
   } > memisl
@@ -199,7 +199,7 @@ SECTIONS {
     __dram_end = .;
   } > dram
 
-  .l3_heap : ALIGN(16) {
+  .l3_heap : ALIGN(32) {
     __l3_heap_start = .;
     __l3_heap_end = ORIGIN(dram) + LENGTH(dram);
   } > dram

--- a/targets/chimera-convolve/link.ld
+++ b/targets/chimera-convolve/link.ld
@@ -34,7 +34,7 @@ SECTIONS {
   } > memisl
 
   /* Thread Local Storage sections */
-  .tdata    :
+  .tdata :
   {
     . = ALIGN(32);
     __tdata_start = .;
@@ -54,72 +54,127 @@ SECTIONS {
   } > memisl
 
   /* Cluster Local Storage sections */
-  .cdata    :
+  .cdata :
   {
     . = ALIGN(32);
     __cdata_start = .;
     *(.cdata .cdata.*)
     . = ALIGN(32);
     __cdata_end = .;
-  } > l1_c4 AT > memisl
+  } > l1_alias AT > memisl
   /* Provide symbols for the load address (LMA) of the .cdata section so
      runtime code can copy the initialized contents from flash/main memory
      instead of using the VMA which points into L1. */
   __cdata_lma_start = LOADADDR(.cdata);
   __cdata_lma_end = LOADADDR(.cdata) + SIZEOF(.cdata);
 
-  .cbss :
+  .cbss (NOLOAD) :
   {
     . = ALIGN(32);
     __cbss_start = .;
     *(.cbss .cbss.*)
     . = ALIGN(32);
     __cbss_end = .;
-  } > l1_c4 AT > memisl
+  } > l1_alias AT > memisl
+
+  __cbss_lma_start = LOADADDR(.cbss);
+  __cbss_lma_end = LOADADDR(.cbss) + SIZEOF(.cbss);
+
+  /* Reserve the rest of cluster-local L1 for general allocations. */
+  __cls_reserved_size = SIZEOF(.cdata) + SIZEOF(.cbss);
 
   .bulk : ALIGN(16) {
     *(.bulk)
     *(.bulk.*)
   } > memisl
 
-  .l2_heap : ALIGN(16) {
-    __l2_heap_start = .;
-    __l2_heap_end = ORIGIN(memisl) + LENGTH(memisl);
-  } > memisl
+  .l1_c0_cls  (NOLOAD): ALIGN(16) {
+    . += __cls_reserved_size;
+  } > l1_c0
 
-  .l1 (NOLOAD) : ALIGN(16) {
-    *(.l1 .l1.*)
-  } > l1
+  .l1_c1_cls  (NOLOAD): ALIGN(16) {
+    . += __cls_reserved_size;
+  } > l1_c1
+
+  .l1_c2_cls  (NOLOAD): ALIGN(16) {
+    . += __cls_reserved_size;
+  } > l1_c2
+  .l1_c3_cls  (NOLOAD): ALIGN(16) {
+    . += __cls_reserved_size;
+  } > l1_c3
+  .l1_c4_cls  (NOLOAD): ALIGN(16) {
+    . += __cls_reserved_size;
+  } > l1_c4
 
   .l1_c0 : ALIGN(16) {
     __l1_c0_start = .;
     *(.l1_c0 .l1_c0.*)
     __l1_c0_end = .;
-  } > l1_c0
+    . = ALIGN(16);
+    __l1_c0_heap_start = .;
+    __l1_c0_heap_end = ORIGIN(l1_c0) + LENGTH(l1_c0);
+  } > l1_c0 AT > memisl
+
+  /* Provide symbols for the load address (LMA) of the .l1_c0 section so
+     runtime code can copy the initialized contents from flash/main memory
+     instead of using the VMA which points into L1.
+     WIESEP: This is also required as JTAG can somehow not access L1 memory...*/
+  __l1_c0_lma_start = LOADADDR(.l1_c0);
+  __l1_c0_lma_end = LOADADDR(.l1_c0) + SIZEOF(.l1_c0);
 
   .l1_c1 : ALIGN(16) {
     __l1_c1_start = .;
     *(.l1_c1 .l1_c1.*)
     __l1_c1_end = .;
-  } > l1_c1
+    . = ALIGN(16);
+    __l1_c1_heap_start = .;
+    __l1_c1_heap_end = ORIGIN(l1_c1) + LENGTH(l1_c1);
+  } > l1_c1 AT > memisl
+
+  __l1_c1_lma_start = LOADADDR(.l1_c1);
+  __l1_c1_lma_end = LOADADDR(.l1_c1) + SIZEOF(.l1_c1);
+
 
   .l1_c2 : ALIGN(16) {
     __l1_c2_start = .;
     *(.l1_c2 .l1_c2.*)
     __l1_c2_end = .;
-  } > l1_c2
+    . = ALIGN(16);
+    __l1_c2_heap_start = .;
+    __l1_c2_heap_end = ORIGIN(l1_c2) + LENGTH(l1_c2);
+  } > l1_c2 AT > memisl
+
+  __l1_c2_lma_start = LOADADDR(.l1_c2);
+  __l1_c2_lma_end = LOADADDR(.l1_c2) + SIZEOF(.l1_c2);
 
   .l1_c3 : ALIGN(16) {
     __l1_c3_start = .;
     *(.l1_c3 .l1_c3.*)
     __l1_c3_end = .;
-  } > l1_c3
+    . = ALIGN(16);
+    __l1_c3_heap_start = .;
+    __l1_c3_heap_end = ORIGIN(l1_c3) + LENGTH(l1_c3);
+  } > l1_c3 AT > memisl
+
+  __l1_c3_lma_start = LOADADDR(.l1_c3);
+  __l1_c3_lma_end = LOADADDR(.l1_c3) + SIZEOF(.l1_c3);
 
   .l1_c4 : ALIGN(16) {
     __l1_c4_start = .;
     *(.l1_c4 .l1_c4.*)
     __l1_c4_end = .;
-  } > l1_c4
+    . = ALIGN(16);
+    __l1_c4_heap_start = .;
+    __l1_c4_heap_end = ORIGIN(l1_c4) + LENGTH(l1_c4);
+  } > l1_c4 AT > memisl
+
+  __l1_c4_lma_start = LOADADDR(.l1_c4);
+  __l1_c4_lma_end = LOADADDR(.l1_c4) + SIZEOF(.l1_c4);
+
+  .l2_heap : ALIGN(16) {
+    __l2_heap_start = .;
+    __l2_heap_end = ORIGIN(memisl) + LENGTH(memisl);
+  } > memisl
 
   .dram :
   {

--- a/targets/chimera-convolve/src/crt0.S
+++ b/targets/chimera-convolve/src/crt0.S
@@ -133,6 +133,9 @@ _trap_handler_wrap:
 trap_vector:
     j trap_vector
 
+
+.section .cbss, "aw", @nobits
+
 .pushsection .htif,"aw",@progbits;
 .align 6; .global tohost; tohost: .dword 0;
 .align 6; .global fromhost; fromhost: .dword 0;

--- a/targets/chimera-convolve/src/soc_addr_map.c
+++ b/targets/chimera-convolve/src/soc_addr_map.c
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2024 ETH Zurich and University of Bologna
+// SPDX-License-Identifier: Apache-2.0
+
+// Single definition of all address arrays declared in soc_addr_map.h.
+// Keeping the definitions here (not in the header) avoids a static copy per
+// translation unit that includes the header.
+
+#include "addr_maps/soc_addr_map.h"
+
+const uintptr_t _chimera_clusterBase[_chimera_numClusters] = {
+    CLUSTER_0_BASE, CLUSTER_1_BASE, CLUSTER_2_BASE, CLUSTER_3_BASE, CLUSTER_4_BASE};
+
+const uintptr_t _chimera_clusterHeapStart[_chimera_numClusters] = {
+    (uintptr_t)__l1_c0_heap_start, (uintptr_t)__l1_c1_heap_start, (uintptr_t)__l1_c2_heap_start,
+    (uintptr_t)__l1_c3_heap_start, (uintptr_t)__l1_c4_heap_start};
+
+const uintptr_t _chimera_clusterL1Start[_chimera_numClusters] = {
+    (uintptr_t)__l1_c0_start, (uintptr_t)__l1_c1_start, (uintptr_t)__l1_c2_start,
+    (uintptr_t)__l1_c3_start, (uintptr_t)__l1_c4_start};
+
+const uintptr_t _chimera_clusterL1End[_chimera_numClusters] = {
+    (uintptr_t)__l1_c0_end, (uintptr_t)__l1_c1_end, (uintptr_t)__l1_c2_end, (uintptr_t)__l1_c3_end,
+    (uintptr_t)__l1_c4_end};
+
+const uintptr_t _chimera_clusterL1LmaStart[_chimera_numClusters] = {
+    (uintptr_t)__l1_c0_lma_start, (uintptr_t)__l1_c1_lma_start, (uintptr_t)__l1_c2_lma_start,
+    (uintptr_t)__l1_c3_lma_start, (uintptr_t)__l1_c4_lma_start};
+
+const uintptr_t _chimera_clusterL1LmaEnd[_chimera_numClusters] = {
+    (uintptr_t)__l1_c0_lma_end, (uintptr_t)__l1_c1_lma_end, (uintptr_t)__l1_c2_lma_end,
+    (uintptr_t)__l1_c3_lma_end, (uintptr_t)__l1_c4_lma_end};

--- a/targets/chimera-host/link.ld
+++ b/targets/chimera-host/link.ld
@@ -10,7 +10,7 @@ SECTIONS {
     *(.text.*)
   } > memisl
 
-  .misc : ALIGN(16) {
+  .misc : ALIGN(32) {
     *(.rodata)
     *(.rodata.*)
     *(.data)
@@ -32,12 +32,12 @@ SECTIONS {
   . = ALIGN(32);
   __bss_end = .;
 
-  .bulk : ALIGN(16) {
+  .bulk : ALIGN(32) {
     *(.bulk)
     *(.bulk.*)
   } > memisl
 
-  .l2_heap : ALIGN(16) {
+  .l2_heap : ALIGN(32) {
     __l2_heap_start = .;
     __l2_heap_end = ORIGIN(memisl) + LENGTH(memisl);
   } > memisl
@@ -49,7 +49,7 @@ SECTIONS {
     __dram_end = .;
   } > dram
 
-  .l3_heap : ALIGN(16) {
+  .l3_heap : ALIGN(32) {
     __l3_heap_start = .;
     __l3_heap_end = ORIGIN(dram) + LENGTH(dram);
   } > dram

--- a/targets/chimera-open/common.ldh
+++ b/targets/chimera-open/common.ldh
@@ -6,7 +6,7 @@
 ENTRY(_start)
 
 MEMORY {
-  l1 (rwx)      : ORIGIN = 0x18000000, LENGTH = 128K
+  l1_alias (rwx): ORIGIN = 0x18000000, LENGTH = 128K
   l1_c0 (rwx)   : ORIGIN = 0x40000000, LENGTH = 128K
   l1_c1 (rwx)   : ORIGIN = 0x40200000, LENGTH = 128K
   l1_c2 (rwx)   : ORIGIN = 0x40400000, LENGTH = 128K
@@ -27,6 +27,8 @@ SECTIONS {
   /* By default, keep the calling context (boot ROM) stack pointer */
   __global_pointer$ = ADDR(.misc) + SIZEOF(.misc) / 2;
   __stack_pointer$  = __stack_start - 8;
+
+  __base_l1_alias = ORIGIN(l1_alias);
 
   /* Further addresses */
   __base_dma      = 0x01000000;

--- a/targets/chimera-open/inc/addr_maps/soc_addr_map.h
+++ b/targets/chimera-open/inc/addr_maps/soc_addr_map.h
@@ -38,6 +38,8 @@
 
 #define CLUSTER_HART_BASE CLUSTER_0_HART_BASE
 
+#define _chimera_numClusters 5
+
 static const uint8_t _chimera_numCores[] = {CLUSTER_0_NUMCORES, CLUSTER_1_NUMCORES,
                                             CLUSTER_2_NUMCORES, CLUSTER_3_NUMCORES,
                                             CLUSTER_4_NUMCORES};
@@ -45,40 +47,31 @@ static const uint8_t _chimera_hartBase[] = {CLUSTER_0_HART_BASE, CLUSTER_1_HART_
                                             CLUSTER_2_HART_BASE, CLUSTER_3_HART_BASE,
                                             CLUSTER_4_HART_BASE};
 
-static const uint32_t _chimera_clusterBase[] = {CLUSTER_0_BASE, CLUSTER_1_BASE, CLUSTER_2_BASE,
-                                                CLUSTER_3_BASE, CLUSTER_4_BASE};
+extern const uintptr_t _chimera_clusterBase[_chimera_numClusters];
 
-extern volatile uint32_t __l1_c0_heap_start, __l1_c1_heap_start, __l1_c2_heap_start,
-    __l1_c3_heap_start, __l1_c4_heap_start;
-static const uint32_t _chimera_clusterHeapStart[] = {
-    (uint32_t)&__l1_c0_heap_start, (uint32_t)&__l1_c1_heap_start, (uint32_t)&__l1_c2_heap_start,
-    (uint32_t)&__l1_c3_heap_start, (uint32_t)&__l1_c4_heap_start};
+extern char __l1_c0_heap_start[], __l1_c1_heap_start[], __l1_c2_heap_start[], __l1_c3_heap_start[],
+    __l1_c4_heap_start[];
+extern const uintptr_t _chimera_clusterHeapStart[_chimera_numClusters];
 
-extern volatile uint32_t __l1_c0_start, __l1_c1_start, __l1_c2_start, __l1_c3_start, __l1_c4_start;
-static const uint32_t _chimera_clusterL1Start[] = {
-    (uint32_t)&__l1_c0_start, (uint32_t)&__l1_c1_start, (uint32_t)&__l1_c2_start,
-    (uint32_t)&__l1_c3_start, (uint32_t)&__l1_c4_start};
+extern char __l1_c0_start[], __l1_c1_start[], __l1_c2_start[], __l1_c3_start[], __l1_c4_start[];
+extern const uintptr_t _chimera_clusterL1Start[_chimera_numClusters];
 
-extern volatile uint32_t __l1_c0_end, __l1_c1_end, __l1_c2_end, __l1_c3_end, __l1_c4_end;
-static const uint32_t _chimera_clusterL1End[] = {(uint32_t)&__l1_c0_end, (uint32_t)&__l1_c1_end,
-                                                 (uint32_t)&__l1_c2_end, (uint32_t)&__l1_c3_end,
-                                                 (uint32_t)&__l1_c4_end};
+extern char __l1_c0_end[], __l1_c1_end[], __l1_c2_end[], __l1_c3_end[], __l1_c4_end[];
+extern const uintptr_t _chimera_clusterL1End[_chimera_numClusters];
 
-extern volatile uint32_t __l1_c0_lma_start, __l1_c1_lma_start, __l1_c2_lma_start, __l1_c3_lma_start,
-    __l1_c4_lma_start;
-static const uint32_t _chimera_clusterL1LmaStart[] = {
-    (uint32_t)&__l1_c0_lma_start, (uint32_t)&__l1_c1_lma_start, (uint32_t)&__l1_c2_lma_start,
-    (uint32_t)&__l1_c3_lma_start, (uint32_t)&__l1_c4_lma_start};
+extern char __l1_c0_lma_start[], __l1_c1_lma_start[], __l1_c2_lma_start[], __l1_c3_lma_start[],
+    __l1_c4_lma_start[];
+extern const uintptr_t _chimera_clusterL1LmaStart[_chimera_numClusters];
 
-extern volatile uint32_t __l1_c0_lma_end, __l1_c1_lma_end, __l1_c2_lma_end, __l1_c3_lma_end,
-    __l1_c4_lma_end;
-static const uint32_t _chimera_clusterL1LmaEnd[] = {
-    (uint32_t)&__l1_c0_lma_end, (uint32_t)&__l1_c1_lma_end, (uint32_t)&__l1_c2_lma_end,
-    (uint32_t)&__l1_c3_lma_end, (uint32_t)&__l1_c4_lma_end};
+extern char __l1_c0_lma_end[], __l1_c1_lma_end[], __l1_c2_lma_end[], __l1_c3_lma_end[],
+    __l1_c4_lma_end[];
+extern const uintptr_t _chimera_clusterL1LmaEnd[_chimera_numClusters];
 
-#define _chimera_numClusters 5
-
+#ifdef CHIMERA_PADFRAME_BASE_ADDRESS
+#undef CHIMERA_PADFRAME_BASE_ADDRESS
+#endif
 #define CHIMERA_PADFRAME_BASE_ADDRESS 0x30002000
+
 #define FLL_BASE_ADDR 0x30003000
 
 #endif

--- a/targets/chimera-open/inc/addr_maps/soc_addr_map.h
+++ b/targets/chimera-open/inc/addr_maps/soc_addr_map.h
@@ -48,6 +48,34 @@ static const uint8_t _chimera_hartBase[] = {CLUSTER_0_HART_BASE, CLUSTER_1_HART_
 static const uint32_t _chimera_clusterBase[] = {CLUSTER_0_BASE, CLUSTER_1_BASE, CLUSTER_2_BASE,
                                                 CLUSTER_3_BASE, CLUSTER_4_BASE};
 
+extern volatile uint32_t __l1_c0_heap_start, __l1_c1_heap_start, __l1_c2_heap_start,
+    __l1_c3_heap_start, __l1_c4_heap_start;
+static const uint32_t _chimera_clusterHeapStart[] = {
+    (uint32_t)&__l1_c0_heap_start, (uint32_t)&__l1_c1_heap_start, (uint32_t)&__l1_c2_heap_start,
+    (uint32_t)&__l1_c3_heap_start, (uint32_t)&__l1_c4_heap_start};
+
+extern volatile uint32_t __l1_c0_start, __l1_c1_start, __l1_c2_start, __l1_c3_start, __l1_c4_start;
+static const uint32_t _chimera_clusterL1Start[] = {
+    (uint32_t)&__l1_c0_start, (uint32_t)&__l1_c1_start, (uint32_t)&__l1_c2_start,
+    (uint32_t)&__l1_c3_start, (uint32_t)&__l1_c4_start};
+
+extern volatile uint32_t __l1_c0_end, __l1_c1_end, __l1_c2_end, __l1_c3_end, __l1_c4_end;
+static const uint32_t _chimera_clusterL1End[] = {(uint32_t)&__l1_c0_end, (uint32_t)&__l1_c1_end,
+                                                 (uint32_t)&__l1_c2_end, (uint32_t)&__l1_c3_end,
+                                                 (uint32_t)&__l1_c4_end};
+
+extern volatile uint32_t __l1_c0_lma_start, __l1_c1_lma_start, __l1_c2_lma_start, __l1_c3_lma_start,
+    __l1_c4_lma_start;
+static const uint32_t _chimera_clusterL1LmaStart[] = {
+    (uint32_t)&__l1_c0_lma_start, (uint32_t)&__l1_c1_lma_start, (uint32_t)&__l1_c2_lma_start,
+    (uint32_t)&__l1_c3_lma_start, (uint32_t)&__l1_c4_lma_start};
+
+extern volatile uint32_t __l1_c0_lma_end, __l1_c1_lma_end, __l1_c2_lma_end, __l1_c3_lma_end,
+    __l1_c4_lma_end;
+static const uint32_t _chimera_clusterL1LmaEnd[] = {
+    (uint32_t)&__l1_c0_lma_end, (uint32_t)&__l1_c1_lma_end, (uint32_t)&__l1_c2_lma_end,
+    (uint32_t)&__l1_c3_lma_end, (uint32_t)&__l1_c4_lma_end};
+
 #define _chimera_numClusters 5
 
 #define CHIMERA_PADFRAME_BASE_ADDRESS 0x30002000

--- a/targets/chimera-open/link.ld
+++ b/targets/chimera-open/link.ld
@@ -77,10 +77,14 @@ SECTIONS {
     __cbss_end = .;
   } > l1_alias AT > memisl
 
+  /* NOTE: .cbss is NOLOAD, so no bytes are written to the LMA by the loader.
+   * Zero-init is performed via the hardware zero-memory region
+   * (see snrt_zero_memory_ptr()). */
   __cbss_lma_start = LOADADDR(.cbss);
   __cbss_lma_end = LOADADDR(.cbss) + SIZEOF(.cbss);
 
-  /* Reserve the rest of cluster-local L1 for general allocations. */
+  /* Total cluster-local storage (CLS) reserved at the base of every cluster's
+   * L1 TCDM.  Must not exceed the l1_alias window (= L1 size per cluster). */
   __cls_reserved_size = SIZEOF(.cdata) + SIZEOF(.cbss);
 
   .bulk : ALIGN(16) {
@@ -106,70 +110,82 @@ SECTIONS {
     . += __cls_reserved_size;
   } > l1_c4
 
+  /* Provide LMA symbols for the .l1_cX sections so the runtime DMA init code
+   * can copy cluster-private initialized data from memisl (LMA) to each
+   * cluster's L1 TCDM (VMA).  Two reasons the LMA copy is necessary:
+   *  1. The binary loader places data at the LMA (memisl); the VMA points
+   *     into cluster L1 which is not reachable by the loader.
+   *  2. Some debug probes (JTAG) cannot reliably access cluster L1 during
+   *     early boot, so the DMA copy from memisl is the only safe path.
+   *
+   * LMA symbols are assigned inside the section body so that lld only
+   * evaluates LOADADDR/SIZEOF when the section actually has input sections.
+   * PROVIDE(...= 0) outside gives a safe fallback: the runtime sees
+   * lma_end - lma_start = 0 and skips the DMA for empty sections. */
   .l1_c0 : ALIGN(16) {
     __l1_c0_start = .;
-    *(.l1_c0 .l1_c0.*)
+    __l1_c0_lma_start = LOADADDR(.l1_c0);
+    KEEP(*(.l1_c0 .l1_c0.*))
     __l1_c0_end = .;
+    __l1_c0_lma_end = LOADADDR(.l1_c0) + SIZEOF(.l1_c0);
     . = ALIGN(16);
     __l1_c0_heap_start = .;
     __l1_c0_heap_end = ORIGIN(l1_c0) + LENGTH(l1_c0);
   } > l1_c0 AT > memisl
-
-  /* Provide symbols for the load address (LMA) of the .l1_c0 section so
-     runtime code can copy the initialized contents from flash/main memory
-     instead of using the VMA which points into L1.
-     WIESEP: This is also required as JTAG can somehow not access L1 memory...*/
-  __l1_c0_lma_start = LOADADDR(.l1_c0);
-  __l1_c0_lma_end = LOADADDR(.l1_c0) + SIZEOF(.l1_c0);
+  PROVIDE(__l1_c0_lma_start = 0);
+  PROVIDE(__l1_c0_lma_end = 0);
 
   .l1_c1 : ALIGN(16) {
     __l1_c1_start = .;
-    *(.l1_c1 .l1_c1.*)
+    __l1_c1_lma_start = LOADADDR(.l1_c1);
+    KEEP(*(.l1_c1 .l1_c1.*))
     __l1_c1_end = .;
+    __l1_c1_lma_end = LOADADDR(.l1_c1) + SIZEOF(.l1_c1);
     . = ALIGN(16);
     __l1_c1_heap_start = .;
     __l1_c1_heap_end = ORIGIN(l1_c1) + LENGTH(l1_c1);
   } > l1_c1 AT > memisl
-
-  __l1_c1_lma_start = LOADADDR(.l1_c1);
-  __l1_c1_lma_end = LOADADDR(.l1_c1) + SIZEOF(.l1_c1);
-
+  PROVIDE(__l1_c1_lma_start = 0);
+  PROVIDE(__l1_c1_lma_end = 0);
 
   .l1_c2 : ALIGN(16) {
     __l1_c2_start = .;
-    *(.l1_c2 .l1_c2.*)
+    __l1_c2_lma_start = LOADADDR(.l1_c2);
+    KEEP(*(.l1_c2 .l1_c2.*))
     __l1_c2_end = .;
+    __l1_c2_lma_end = LOADADDR(.l1_c2) + SIZEOF(.l1_c2);
     . = ALIGN(16);
     __l1_c2_heap_start = .;
     __l1_c2_heap_end = ORIGIN(l1_c2) + LENGTH(l1_c2);
   } > l1_c2 AT > memisl
-
-  __l1_c2_lma_start = LOADADDR(.l1_c2);
-  __l1_c2_lma_end = LOADADDR(.l1_c2) + SIZEOF(.l1_c2);
+  PROVIDE(__l1_c2_lma_start = 0);
+  PROVIDE(__l1_c2_lma_end = 0);
 
   .l1_c3 : ALIGN(16) {
     __l1_c3_start = .;
-    *(.l1_c3 .l1_c3.*)
+    __l1_c3_lma_start = LOADADDR(.l1_c3);
+    KEEP(*(.l1_c3 .l1_c3.*))
     __l1_c3_end = .;
+    __l1_c3_lma_end = LOADADDR(.l1_c3) + SIZEOF(.l1_c3);
     . = ALIGN(16);
     __l1_c3_heap_start = .;
     __l1_c3_heap_end = ORIGIN(l1_c3) + LENGTH(l1_c3);
   } > l1_c3 AT > memisl
-
-  __l1_c3_lma_start = LOADADDR(.l1_c3);
-  __l1_c3_lma_end = LOADADDR(.l1_c3) + SIZEOF(.l1_c3);
+  PROVIDE(__l1_c3_lma_start = 0);
+  PROVIDE(__l1_c3_lma_end = 0);
 
   .l1_c4 : ALIGN(16) {
     __l1_c4_start = .;
-    *(.l1_c4 .l1_c4.*)
+    __l1_c4_lma_start = LOADADDR(.l1_c4);
+    KEEP(*(.l1_c4 .l1_c4.*))
     __l1_c4_end = .;
+    __l1_c4_lma_end = LOADADDR(.l1_c4) + SIZEOF(.l1_c4);
     . = ALIGN(16);
     __l1_c4_heap_start = .;
     __l1_c4_heap_end = ORIGIN(l1_c4) + LENGTH(l1_c4);
   } > l1_c4 AT > memisl
-
-  __l1_c4_lma_start = LOADADDR(.l1_c4);
-  __l1_c4_lma_end = LOADADDR(.l1_c4) + SIZEOF(.l1_c4);
+  PROVIDE(__l1_c4_lma_start = 0);
+  PROVIDE(__l1_c4_lma_end = 0);
 
   .l2_heap : ALIGN(16) {
     __l2_heap_start = .;

--- a/targets/chimera-open/link.ld
+++ b/targets/chimera-open/link.ld
@@ -1,6 +1,7 @@
 /* SPDX-FileCopyrightText: 2022 ETH Zurich and University of Bologna */
 /* SPDX-License-Identifier: Apache-2.0 */
 
+
 INCLUDE common.ldh
 
 SECTIONS {
@@ -33,7 +34,7 @@ SECTIONS {
   } > memisl
 
   /* Thread Local Storage sections */
-  .tdata    :
+  .tdata :
   {
     . = ALIGN(32);
     __tdata_start = .;
@@ -53,72 +54,127 @@ SECTIONS {
   } > memisl
 
   /* Cluster Local Storage sections */
-  .cdata    :
+  .cdata :
   {
     . = ALIGN(32);
     __cdata_start = .;
     *(.cdata .cdata.*)
     . = ALIGN(32);
     __cdata_end = .;
-  } > l1_c4 AT > memisl
+  } > l1_alias AT > memisl
   /* Provide symbols for the load address (LMA) of the .cdata section so
      runtime code can copy the initialized contents from flash/main memory
      instead of using the VMA which points into L1. */
   __cdata_lma_start = LOADADDR(.cdata);
   __cdata_lma_end = LOADADDR(.cdata) + SIZEOF(.cdata);
 
-  .cbss :
+  .cbss (NOLOAD) :
   {
     . = ALIGN(32);
     __cbss_start = .;
     *(.cbss .cbss.*)
     . = ALIGN(32);
     __cbss_end = .;
-  } > l1_c4 AT > memisl
+  } > l1_alias AT > memisl
+
+  __cbss_lma_start = LOADADDR(.cbss);
+  __cbss_lma_end = LOADADDR(.cbss) + SIZEOF(.cbss);
+
+  /* Reserve the rest of cluster-local L1 for general allocations. */
+  __cls_reserved_size = SIZEOF(.cdata) + SIZEOF(.cbss);
 
   .bulk : ALIGN(16) {
     *(.bulk)
     *(.bulk.*)
   } > memisl
 
-  .l2_heap : ALIGN(16) {
-    __l2_heap_start = .;
-    __l2_heap_end = ORIGIN(memisl) + LENGTH(memisl);
-  } > memisl
+  .l1_c0_cls  (NOLOAD): ALIGN(16) {
+    . += __cls_reserved_size;
+  } > l1_c0
 
-  .l1 (NOLOAD) : ALIGN(16) {
-    *(.l1 .l1.*)
-  } > l1
+  .l1_c1_cls  (NOLOAD): ALIGN(16) {
+    . += __cls_reserved_size;
+  } > l1_c1
+
+  .l1_c2_cls  (NOLOAD): ALIGN(16) {
+    . += __cls_reserved_size;
+  } > l1_c2
+  .l1_c3_cls  (NOLOAD): ALIGN(16) {
+    . += __cls_reserved_size;
+  } > l1_c3
+  .l1_c4_cls  (NOLOAD): ALIGN(16) {
+    . += __cls_reserved_size;
+  } > l1_c4
 
   .l1_c0 : ALIGN(16) {
     __l1_c0_start = .;
     *(.l1_c0 .l1_c0.*)
     __l1_c0_end = .;
-  } > l1_c0
+    . = ALIGN(16);
+    __l1_c0_heap_start = .;
+    __l1_c0_heap_end = ORIGIN(l1_c0) + LENGTH(l1_c0);
+  } > l1_c0 AT > memisl
+
+  /* Provide symbols for the load address (LMA) of the .l1_c0 section so
+     runtime code can copy the initialized contents from flash/main memory
+     instead of using the VMA which points into L1.
+     WIESEP: This is also required as JTAG can somehow not access L1 memory...*/
+  __l1_c0_lma_start = LOADADDR(.l1_c0);
+  __l1_c0_lma_end = LOADADDR(.l1_c0) + SIZEOF(.l1_c0);
 
   .l1_c1 : ALIGN(16) {
     __l1_c1_start = .;
     *(.l1_c1 .l1_c1.*)
     __l1_c1_end = .;
-  } > l1_c1
+    . = ALIGN(16);
+    __l1_c1_heap_start = .;
+    __l1_c1_heap_end = ORIGIN(l1_c1) + LENGTH(l1_c1);
+  } > l1_c1 AT > memisl
+
+  __l1_c1_lma_start = LOADADDR(.l1_c1);
+  __l1_c1_lma_end = LOADADDR(.l1_c1) + SIZEOF(.l1_c1);
+
 
   .l1_c2 : ALIGN(16) {
     __l1_c2_start = .;
     *(.l1_c2 .l1_c2.*)
     __l1_c2_end = .;
-  } > l1_c2
+    . = ALIGN(16);
+    __l1_c2_heap_start = .;
+    __l1_c2_heap_end = ORIGIN(l1_c2) + LENGTH(l1_c2);
+  } > l1_c2 AT > memisl
+
+  __l1_c2_lma_start = LOADADDR(.l1_c2);
+  __l1_c2_lma_end = LOADADDR(.l1_c2) + SIZEOF(.l1_c2);
 
   .l1_c3 : ALIGN(16) {
     __l1_c3_start = .;
     *(.l1_c3 .l1_c3.*)
     __l1_c3_end = .;
-  } > l1_c3
+    . = ALIGN(16);
+    __l1_c3_heap_start = .;
+    __l1_c3_heap_end = ORIGIN(l1_c3) + LENGTH(l1_c3);
+  } > l1_c3 AT > memisl
+
+  __l1_c3_lma_start = LOADADDR(.l1_c3);
+  __l1_c3_lma_end = LOADADDR(.l1_c3) + SIZEOF(.l1_c3);
 
   .l1_c4 : ALIGN(16) {
     __l1_c4_start = .;
     *(.l1_c4 .l1_c4.*)
     __l1_c4_end = .;
-  } > l1_c4
+    . = ALIGN(16);
+    __l1_c4_heap_start = .;
+    __l1_c4_heap_end = ORIGIN(l1_c4) + LENGTH(l1_c4);
+  } > l1_c4 AT > memisl
+
+  __l1_c4_lma_start = LOADADDR(.l1_c4);
+  __l1_c4_lma_end = LOADADDR(.l1_c4) + SIZEOF(.l1_c4);
+
+  .l2_heap : ALIGN(16) {
+    __l2_heap_start = .;
+    __l2_heap_end = ORIGIN(memisl) + LENGTH(memisl);
+  } > memisl
 
   .dram :
   {

--- a/targets/chimera-open/link.ld
+++ b/targets/chimera-open/link.ld
@@ -11,7 +11,7 @@ SECTIONS {
     *(.text.*)
   } > memisl
 
-  .misc : ALIGN(16) {
+  .misc : ALIGN(32) {
     *(.rodata)
     *(.rodata.*)
     *(.data)
@@ -87,26 +87,26 @@ SECTIONS {
    * L1 TCDM.  Must not exceed the l1_alias window (= L1 size per cluster). */
   __cls_reserved_size = SIZEOF(.cdata) + SIZEOF(.cbss);
 
-  .bulk : ALIGN(16) {
+  .bulk : ALIGN(32) {
     *(.bulk)
     *(.bulk.*)
   } > memisl
 
-  .l1_c0_cls  (NOLOAD): ALIGN(16) {
+  .l1_c0_cls  (NOLOAD): ALIGN(32) {
     . += __cls_reserved_size;
   } > l1_c0
 
-  .l1_c1_cls  (NOLOAD): ALIGN(16) {
+  .l1_c1_cls  (NOLOAD): ALIGN(32) {
     . += __cls_reserved_size;
   } > l1_c1
 
-  .l1_c2_cls  (NOLOAD): ALIGN(16) {
+  .l1_c2_cls  (NOLOAD): ALIGN(32) {
     . += __cls_reserved_size;
   } > l1_c2
-  .l1_c3_cls  (NOLOAD): ALIGN(16) {
+  .l1_c3_cls  (NOLOAD): ALIGN(32) {
     . += __cls_reserved_size;
   } > l1_c3
-  .l1_c4_cls  (NOLOAD): ALIGN(16) {
+  .l1_c4_cls  (NOLOAD): ALIGN(32) {
     . += __cls_reserved_size;
   } > l1_c4
 
@@ -122,72 +122,72 @@ SECTIONS {
    * evaluates LOADADDR/SIZEOF when the section actually has input sections.
    * PROVIDE(...= 0) outside gives a safe fallback: the runtime sees
    * lma_end - lma_start = 0 and skips the DMA for empty sections. */
-  .l1_c0 : ALIGN(16) {
+  .l1_c0 : ALIGN(32) {
     __l1_c0_start = .;
     __l1_c0_lma_start = LOADADDR(.l1_c0);
     KEEP(*(.l1_c0 .l1_c0.*))
     __l1_c0_end = .;
     __l1_c0_lma_end = LOADADDR(.l1_c0) + SIZEOF(.l1_c0);
-    . = ALIGN(16);
+    . = ALIGN(32);
     __l1_c0_heap_start = .;
     __l1_c0_heap_end = ORIGIN(l1_c0) + LENGTH(l1_c0);
   } > l1_c0 AT > memisl
   PROVIDE(__l1_c0_lma_start = 0);
   PROVIDE(__l1_c0_lma_end = 0);
 
-  .l1_c1 : ALIGN(16) {
+  .l1_c1 : ALIGN(32) {
     __l1_c1_start = .;
     __l1_c1_lma_start = LOADADDR(.l1_c1);
     KEEP(*(.l1_c1 .l1_c1.*))
     __l1_c1_end = .;
     __l1_c1_lma_end = LOADADDR(.l1_c1) + SIZEOF(.l1_c1);
-    . = ALIGN(16);
+    . = ALIGN(32);
     __l1_c1_heap_start = .;
     __l1_c1_heap_end = ORIGIN(l1_c1) + LENGTH(l1_c1);
   } > l1_c1 AT > memisl
   PROVIDE(__l1_c1_lma_start = 0);
   PROVIDE(__l1_c1_lma_end = 0);
 
-  .l1_c2 : ALIGN(16) {
+  .l1_c2 : ALIGN(32) {
     __l1_c2_start = .;
     __l1_c2_lma_start = LOADADDR(.l1_c2);
     KEEP(*(.l1_c2 .l1_c2.*))
     __l1_c2_end = .;
     __l1_c2_lma_end = LOADADDR(.l1_c2) + SIZEOF(.l1_c2);
-    . = ALIGN(16);
+    . = ALIGN(32);
     __l1_c2_heap_start = .;
     __l1_c2_heap_end = ORIGIN(l1_c2) + LENGTH(l1_c2);
   } > l1_c2 AT > memisl
   PROVIDE(__l1_c2_lma_start = 0);
   PROVIDE(__l1_c2_lma_end = 0);
 
-  .l1_c3 : ALIGN(16) {
+  .l1_c3 : ALIGN(32) {
     __l1_c3_start = .;
     __l1_c3_lma_start = LOADADDR(.l1_c3);
     KEEP(*(.l1_c3 .l1_c3.*))
     __l1_c3_end = .;
     __l1_c3_lma_end = LOADADDR(.l1_c3) + SIZEOF(.l1_c3);
-    . = ALIGN(16);
+    . = ALIGN(32);
     __l1_c3_heap_start = .;
     __l1_c3_heap_end = ORIGIN(l1_c3) + LENGTH(l1_c3);
   } > l1_c3 AT > memisl
   PROVIDE(__l1_c3_lma_start = 0);
   PROVIDE(__l1_c3_lma_end = 0);
 
-  .l1_c4 : ALIGN(16) {
+  .l1_c4 : ALIGN(32) {
     __l1_c4_start = .;
     __l1_c4_lma_start = LOADADDR(.l1_c4);
     KEEP(*(.l1_c4 .l1_c4.*))
     __l1_c4_end = .;
     __l1_c4_lma_end = LOADADDR(.l1_c4) + SIZEOF(.l1_c4);
-    . = ALIGN(16);
+    . = ALIGN(32);
     __l1_c4_heap_start = .;
     __l1_c4_heap_end = ORIGIN(l1_c4) + LENGTH(l1_c4);
   } > l1_c4 AT > memisl
   PROVIDE(__l1_c4_lma_start = 0);
   PROVIDE(__l1_c4_lma_end = 0);
 
-  .l2_heap : ALIGN(16) {
+  .l2_heap : ALIGN(32) {
     __l2_heap_start = .;
     __l2_heap_end = ORIGIN(memisl) + LENGTH(memisl);
   } > memisl
@@ -199,7 +199,7 @@ SECTIONS {
     __dram_end = .;
   } > dram
 
-  .l3_heap : ALIGN(16) {
+  .l3_heap : ALIGN(32) {
     __l3_heap_start = .;
     __l3_heap_end = ORIGIN(dram) + LENGTH(dram);
   } > dram

--- a/targets/chimera-open/src/crt0.S
+++ b/targets/chimera-open/src/crt0.S
@@ -133,6 +133,8 @@ _trap_handler_wrap:
 trap_vector:
     j trap_vector
 
+.section .cbss, "aw", @nobits
+
 .pushsection .htif,"aw",@progbits;
 .align 6; .global tohost; tohost: .dword 0;
 .align 6; .global fromhost; fromhost: .dword 0;

--- a/targets/chimera-open/src/soc_addr_map.c
+++ b/targets/chimera-open/src/soc_addr_map.c
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2024 ETH Zurich and University of Bologna
+// SPDX-License-Identifier: Apache-2.0
+
+// Single definition of all address arrays declared in soc_addr_map.h.
+// Keeping the definitions here (not in the header) avoids a static copy per
+// translation unit that includes the header.
+
+#include "addr_maps/soc_addr_map.h"
+
+const uintptr_t _chimera_clusterBase[_chimera_numClusters] = {
+    CLUSTER_0_BASE, CLUSTER_1_BASE, CLUSTER_2_BASE, CLUSTER_3_BASE, CLUSTER_4_BASE};
+
+const uintptr_t _chimera_clusterHeapStart[_chimera_numClusters] = {
+    (uintptr_t)__l1_c0_heap_start, (uintptr_t)__l1_c1_heap_start, (uintptr_t)__l1_c2_heap_start,
+    (uintptr_t)__l1_c3_heap_start, (uintptr_t)__l1_c4_heap_start};
+
+const uintptr_t _chimera_clusterL1Start[_chimera_numClusters] = {
+    (uintptr_t)__l1_c0_start, (uintptr_t)__l1_c1_start, (uintptr_t)__l1_c2_start,
+    (uintptr_t)__l1_c3_start, (uintptr_t)__l1_c4_start};
+
+const uintptr_t _chimera_clusterL1End[_chimera_numClusters] = {
+    (uintptr_t)__l1_c0_end, (uintptr_t)__l1_c1_end, (uintptr_t)__l1_c2_end, (uintptr_t)__l1_c3_end,
+    (uintptr_t)__l1_c4_end};
+
+const uintptr_t _chimera_clusterL1LmaStart[_chimera_numClusters] = {
+    (uintptr_t)__l1_c0_lma_start, (uintptr_t)__l1_c1_lma_start, (uintptr_t)__l1_c2_lma_start,
+    (uintptr_t)__l1_c3_lma_start, (uintptr_t)__l1_c4_lma_start};
+
+const uintptr_t _chimera_clusterL1LmaEnd[_chimera_numClusters] = {
+    (uintptr_t)__l1_c0_lma_end, (uintptr_t)__l1_c1_lma_end, (uintptr_t)__l1_c2_lma_end,
+    (uintptr_t)__l1_c3_lma_end, (uintptr_t)__l1_c4_lma_end};

--- a/tests/snitchCluster/matmul/src_cluster/test_cluster.c
+++ b/tests/snitchCluster/matmul/src_cluster/test_cluster.c
@@ -118,20 +118,20 @@ void MatMul_unrolled_2x2_parallel_s8_rv32im(int8_t const *__restrict__ pSrcA,
  * These are assigned on the DM (data-mover) core and then used by compute
  * cores.
  */
-int8_t __attribute__((__section__(".cbss"))) * DeeployNetwork_input_0;
-int8_t __attribute__((__section__(".cbss"))) * DeeployNetwork_input_1;
-int32_t __attribute__((__section__(".cbss"))) * DeeployNetwork_output_0;
+SNRT_CLUSTER_L1_ZERO(int8_t *DeeployNetwork_input_0);
+SNRT_CLUSTER_L1_ZERO(int8_t *DeeployNetwork_input_1);
+SNRT_CLUSTER_L1_ZERO(int32_t *DeeployNetwork_output_0);
 
 /*
  * Accumulator for ops-per-cycle computed by each compute core and atomically
  * added to this shared float in .cdata.
  */
-static __attribute__((__section__(".cdata"))) float ops_per_cycle = 0.0f;
+SNRT_CLUSTER_L1_COPY(static float ops_per_cycle) = 0.0f;
 
 /**
+ *
  * @brief Main function of the cluster test.
  *
- * @return int Return 0 if the test was successful, -1 otherwise.
  */
 int32_t testReturn(void *args) {
 

--- a/tests/snitchCluster/snrt/src_cluster/test_cluster.c
+++ b/tests/snitchCluster/snrt/src_cluster/test_cluster.c
@@ -84,9 +84,9 @@ int32_t testReturn(void *args) {
     *reg32((void *)SOC_CTRL_BASE, CHIMERA_SNITCH_INTR_HANDLER_ADDR_REG_OFFSET) =
         (uint32_t)clusterDefaultHandler;
 
-    extern char __tbss_start, __tbss_end, __tdata_start, __tdata_end;
-    extern volatile uint32_t __cbss_start, __cbss_end, __cdata_start, __cdata_end;
-    extern char __cdata_lma_start, __cdata_lma_end;
+    extern char __tbss_start[], __tbss_end[], __tdata_start[], __tdata_end[];
+    extern char __cbss_start[], __cbss_end[], __cdata_start[], __cdata_end[];
+    extern char __cdata_lma_start[], __cdata_lma_end[];
 
     snrt_init();
 

--- a/tests/snitchCluster/snrt/src_cluster/test_cluster.c
+++ b/tests/snitchCluster/snrt/src_cluster/test_cluster.c
@@ -18,18 +18,26 @@
 // Include Runtime Headers
 #include "snrt.h"
 
-#define __cluster_data __attribute__((__section__(".cdata")))
-#define __cluster_bss __attribute__((__section__(".cbss")))
-
-static __cluster_data int8_t cluster_local_var1 = 1;
-static __cluster_bss int8_t cluster_local_var2[64];
-static __cluster_data int8_t cluster_local_var3 = 3;
-static __cluster_data int8_t cluster_local_var4 = 4;
+SNRT_CLUSTER_L1_COPY(static volatile int8_t cluster_local_var1) = 1;
+SNRT_CLUSTER_L1_ZERO(static volatile int cluster_local_var2[64]);
 
 static __thread int32_t thread_local_var1 = 1;
 static __thread int32_t thread_local_var2[64];
-static __thread int32_t thread_local_var3 = 3;
-static __thread int32_t thread_local_var4 = 4;
+
+SNRT_CLUSTER_L1(static int32_t cluster0_private_var1, 0) = 0x1;
+SNRT_CLUSTER_L1(static int32_t cluster0_private_var2[8], 0);
+
+SNRT_CLUSTER_L1(static int32_t cluster1_private_var1, 1) = 0x11;
+SNRT_CLUSTER_L1(static int32_t cluster1_private_var2[16], 1);
+
+SNRT_CLUSTER_L1(static int32_t cluster2_private_var1, 2) = 0x21;
+SNRT_CLUSTER_L1(static int32_t cluster2_private_var2[24], 2);
+
+SNRT_CLUSTER_L1(static int32_t cluster3_private_var1, 3) = 0x31;
+SNRT_CLUSTER_L1(static int32_t cluster3_private_var2[32], 3);
+
+SNRT_CLUSTER_L1(static int32_t cluster4_private_var1, 4) = 0x41;
+SNRT_CLUSTER_L1(static int32_t cluster4_private_var2[40], 4);
 
 /**
  * @brief Interrupt handler for the cluster, which clears the interrupt flag for the current hart.
@@ -59,12 +67,23 @@ __attribute__((naked)) void clusterInterruptHandler() {
     );
 }
 
+void clusterDefaultHandler() {
+    *reg32(&__base_clint, CLINT_MSIP_REG_OFFSET) = 0;
+
+    while (1) {
+    };
+}
+
 /**
  * @brief Main function of the cluster test.
  *
  * @return int Return 0 if the test was successful, -1 otherwise.
  */
 int32_t testReturn(void *args) {
+
+    *reg32((void *)SOC_CTRL_BASE, CHIMERA_SNITCH_INTR_HANDLER_ADDR_REG_OFFSET) =
+        (uint32_t)clusterDefaultHandler;
+
     extern char __tbss_start, __tbss_end, __tdata_start, __tdata_end;
     extern volatile uint32_t __cbss_start, __cbss_end, __cdata_start, __cdata_end;
     extern char __cdata_lma_start, __cdata_lma_end;
@@ -72,50 +91,63 @@ int32_t testReturn(void *args) {
     snrt_init();
 
     if (snrt_is_dm_core()) {
-        size_t size_tdata = (size_t)(&__tdata_end) - (size_t)(&__tdata_start);
-        size_t size_ctbss = (size_t)(&__tbss_end) - (size_t)(&__tbss_start);
-        size_t size_cdata = (size_t)(&__cdata_end) - (size_t)(&__cdata_start);
-        size_t size_cbss = (size_t)(&__cbss_end) - (size_t)(&__cbss_start);
+        printf("Cluster Local Data 1 @ %p = %#x\n", &cluster_local_var1, cluster_local_var1);
+        printf("Cluster Local Data 2 @ %p = %#x\n", &cluster_local_var2, cluster_local_var2[0]);
+        cluster_local_var2[0] = snrt_cluster_idx();
+        printf("Cluster Local Data 2 @ %p = %#x\n", &cluster_local_var2, cluster_local_var2[0]);
 
-        printf("Size of .tbss  : %6d bytes (%p - %p)\n", size_ctbss, &__tbss_start, &__tbss_end);
-        printf("Size of .tdata : %6d bytes (%p - %p)\n", size_tdata, &__tdata_start, &__tdata_end);
-        printf("Size of .cdata : %6d bytes (%p - %p)\n", size_cdata, &__cdata_start, &__cdata_end);
-        printf("Size of .cbss  : %6d bytes (%p - %p)\n", size_cbss, &__cbss_start, &__cbss_end);
-
-        printf("Cluster Local Data @ %p = %#x\n", &cluster_local_var1, cluster_local_var1);
-        printf("Cluster Local Data @ %p = %#x\n", &cluster_local_var2, cluster_local_var2[0]);
-        printf("Cluster Local Data @ %p = %#x\n", &cluster_local_var3, cluster_local_var3);
-        printf("Cluster Local Data @ %p = %#x\n", &cluster_local_var4, cluster_local_var4);
+        if (snrt_cluster_idx() == 0) {
+            printf("Cluster 0 Private Data 1 @ %p = %#x\n", &cluster0_private_var1,
+                   cluster0_private_var1);
+            printf("Cluster 0 Private Data 2 @ %p = %#x\n", &cluster0_private_var2,
+                   cluster0_private_var2[0]);
+            cluster0_private_var2[0] = snrt_cluster_idx();
+            printf("Cluster 0 Private Data 2 @ %p = %#x\n", &cluster0_private_var2,
+                   cluster0_private_var2[0]);
+        } else if (snrt_cluster_idx() == 1) {
+            printf("Cluster 1 Private Data 1 @ %p = %#x\n", &cluster1_private_var1,
+                   cluster1_private_var1);
+            printf("Cluster 1 Private Data 2 @ %p = %#x\n", &cluster1_private_var2,
+                   cluster1_private_var2[0]);
+            cluster1_private_var2[0] = snrt_cluster_idx();
+            printf("Cluster 1 Private Data 2 @ %p = %#x\n", &cluster1_private_var2,
+                   cluster1_private_var2[0]);
+        } else if (snrt_cluster_idx() == 2) {
+            printf("Cluster 2 Private Data 1 @ %p = %#x\n", &cluster2_private_var1,
+                   cluster2_private_var1);
+            printf("Cluster 2 Private Data 2 @ %p = %#x\n", &cluster2_private_var2,
+                   cluster2_private_var2[0]);
+            cluster2_private_var2[0] = snrt_cluster_idx();
+            printf("Cluster 2 Private Data 2 @ %p = %#x\n", &cluster2_private_var2,
+                   cluster2_private_var2[0]);
+        } else if (snrt_cluster_idx() == 3) {
+            printf("Cluster 3 Private Data 1 @ %p = %#x\n", &cluster3_private_var1,
+                   cluster3_private_var1);
+            printf("Cluster 3 Private Data 2 @ %p = %#x\n", &cluster3_private_var2,
+                   cluster3_private_var2[0]);
+            cluster3_private_var2[0] = snrt_cluster_idx();
+            printf("Cluster 3 Private Data 2 @ %p = %#x\n", &cluster3_private_var2,
+                   cluster3_private_var2[0]);
+        } else if (snrt_cluster_idx() == 4) {
+            printf("Cluster 4 Private Data 1 @ %p = %#x\n", &cluster4_private_var1,
+                   cluster4_private_var1);
+            printf("Cluster 4 Private Data 2 @ %p = %#x\n", &cluster4_private_var2,
+                   cluster4_private_var2[0]);
+            cluster4_private_var2[0] = snrt_cluster_idx();
+            printf("Cluster 4 Private Data 2 @ %p = %#x\n", &cluster4_private_var2,
+                   cluster4_private_var2[0]);
+        }
     }
 
     snrt_cluster_hw_barrier();
 
-    printf("Cluster Local Storage @ %p = %#x\n", &_cls_ptr, cls());
-
-    printf("Var 1 @ %p = %#x\n", &thread_local_var1, thread_local_var1);
-    printf("Var 2 @ %p = %#x\n", &thread_local_var2, thread_local_var2[0]);
-    printf("Var 3 @ %p = %#x\n", &thread_local_var3, thread_local_var3);
-    printf("Var 4 @ %p = %#x\n", &thread_local_var4, thread_local_var4);
-
-    if (snrt_is_dm_core()) {
-        printf("L1 Allocator @ %p:\n", snrt_l1_allocator());
-        printf("  base @ %p = %#x\n", &snrt_l1_allocator()->base, snrt_l1_allocator()->base);
-        printf("  end  @ %p = %#x\n", &snrt_l1_allocator()->end, snrt_l1_allocator()->end);
-        printf("  next @ %p = %#x\n", &snrt_l1_allocator()->next, snrt_l1_allocator()->next);
-
-        printf("L3 Allocator @ %p:\n", snrt_l3_allocator());
-        printf("  base @ %p = %#x\n", &snrt_l3_allocator()->base, snrt_l3_allocator()->base);
-        printf("  end  @ %p = %#x\n", &snrt_l3_allocator()->end, snrt_l3_allocator()->end);
-        printf("  next @ %p = %#x\n", &snrt_l3_allocator()->next, snrt_l3_allocator()->next);
-    }
-
-    snrt_cluster_hw_barrier();
-
-    if (snrt_is_dm_core()) {
-        snrt_dma_start_1d((void *)(&__cdata_start), (void *)(&__cdata_lma_start), 64);
-        snrt_dma_start_1d((void *)(&__cbss_start), (void *)(snrt_zero_memory_ptr()), 64);
-        snrt_dma_wait_all();
-    }
+    printf("Core %d Local Data 1 @ %p = %#x\n", snrt_cluster_core_idx(), &thread_local_var1,
+           thread_local_var1);
+    printf("Core %d Local Data 2 @ %p = %#x\n", snrt_cluster_core_idx(), &thread_local_var2,
+           thread_local_var2[0]);
+    thread_local_var2[0] = snrt_cluster_core_idx();
+    printf("Core %d Local Data 2 @ %p = %#x\n", snrt_cluster_core_idx(), &thread_local_var2,
+           thread_local_var2[0]);
 
     snrt_cluster_hw_barrier();
     return 0;


### PR DESCRIPTION
# Changelog
This PR introduces fixes to ensure the correct handling of cluster-local and cluster-private storage in a multi-cluster setup.

## Usage Examples

- **L1 Data** (initialized data in L1 of cluster X): 
```c
SNRT_CLUSTER_L1(static int32_t cluster0_private_var1, 0) = 0x1;
SNRT_CLUSTER_L1(static int32_t cluster0_private_var2[8], 0);
```

- **L1 Copy Data** (initialized data in L1 of all clusters, each cluster has a local version): 
```c
SNRT_CLUSTER_L1_COPY(static int8_t cluster_local_var1) = 1;
```

- **L1 Zero Data** (zero-initialized data in L1 of all clusters, each cluster has a local version): 
```c
SNRT_CLUSTER_L1_ZERO(static volatile int cluster_local_var2[64]);
```

## How It Works

The cluster-local storage (CLS) mechanism uses a combination of linker script sections and runtime initialization to enable efficient per-cluster data storage:

### 1. L1 Alias Memory Region
The implementation requires a **TCDM alias memory region** that provides a unified address space mapping to each cluster's local L1 memory. When code running on a specific cluster accesses an address in the L1 alias region, it is automatically routed to that cluster's local L1 memory.

### 2. Linker Script Setup
The linker script defines special sections with split VMA (Virtual Memory Address) and LMA (Load Memory Address):

- **`.cdata` section** (`SNRT_CLUSTER_L1_COPY`): Initialized cluster-local data
  - VMA: `l1_alias` (accessed via L1 alias region)
  - LMA: `memisl` (stored in main memory/flash)
  
- **`.cbss` section** (`SNRT_CLUSTER_L1_ZERO`): Zero-initialized cluster-local data
  - VMA: `l1_alias` (accessed via L1 alias region)
  - LMA: `memisl` (metadata stored in main memory)

- **`.l1_cX` sections** (`SNRT_CLUSTER_L1`): Cluster-private data for specific clusters
  - VMA: Cluster X's L1 memory
  - LMA: `memisl` (stored in main memory/flash)

For each cluster, the linker reserves space (`.l1_cX_cls`) equal to the size of `.cdata` + `.cbss` sections.

### 3. Runtime Initialization
During `snrt_init()`, the DM (Data Mover) core of each cluster:

1. **Copies cluster-local initialized data**: DMA transfers `.cdata` contents from main memory (LMA) to the cluster's actual L1 memory. The destination address is calculated by translating the L1 alias address to the physical cluster L1 address:
   ```
   destination = __cdata_start - __base_l1_alias + _chimera_clusterBase[cluster_idx]
   ```

2. **Zeros cluster-local BSS data**: DMA fills the `.cbss` section in the cluster's L1 memory with zeros using a similar address translation.

3. **Copies cluster-private data**: For cluster-specific sections (`.l1_cX`), DMA copies data from main memory directly to the designated cluster's L1.

### 4. Access Pattern
After initialization, all cores access cluster-local variables using the same variable names and addresses (via the L1 alias region). The hardware automatically routes each access to the appropriate cluster's local copy, ensuring:
- **Zero-copy access**: No runtime overhead once initialized
- **Uniform code**: Same code works across all clusters
- **Per-cluster state**: Each cluster maintains its own copy of the data

This design enables efficient multi-cluster programming with isolated per-cluster state while maintaining code simplicity.

## Added
- New macros for cluster-private storage: `SNRT_CLUSTER_L1()`
- New macros for cluster-local copy data: `SNRT_CLUSTER_L1_COPY()`
- New macros for cluster-local zero data: `SNRT_CLUSTER_L1_ZERO()`
- TCDM alias support in address maps for both Chimera targets

## Changed
- Updated linker scripts for Chimera targets (chimera-convolve and chimera-open) to support cluster-local and cluster-private storage
- Modified runtime initialization code in `init.c` to properly handle multi-cluster storage
- Updated `snrt.h` with new cluster storage utilities
- Enhanced `util.h` with cluster storage handling functions
- Updated tests to use new cluster storage macros

## Fixed
- Properly support cluster-local and cluster-private storage for all clusters

## Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
2. [x] The documentation is updated.
3. [x] All checks are passing.