### PR TITLE
Generic Test Infrastructure with Multi-Cluster Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 ETH Zurich and University of Bologna
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.22)
 
 # VIVIANEP: We need the C11 standard (or later) for building
 #           the OpenTitan peripheral drivers

--- a/cmake/picolibc.cmake
+++ b/cmake/picolibc.cmake
@@ -48,7 +48,7 @@ string(JOIN "," PICOLIB_MULTILIB ${PICOLIB_MULTILIB})
 ExternalProject_Add(
     picolibc
     GIT_REPOSITORY https://github.com/picolibc/picolibc.git
-    GIT_TAG main
+    GIT_TAG 1.8.11
     SOURCE_DIR ${PICOLIBC_SRC_DIR}
     BINARY_DIR ${PICOLIBC_BUILD_DIR}
     INSTALL_DIR ${PICOLIBC_INSTALL_DIR}

--- a/devices/snitch_cluster/runtime/putc.c
+++ b/devices/snitch_cluster/runtime/putc.c
@@ -9,6 +9,8 @@
 
 #include "snrt.h"
 
+#include "soc.h"
+
 volatile uint32_t *_snrt_printf_mutex_ptr;
 
 void snrt_printf_init() {
@@ -76,6 +78,9 @@ int snrt_putchar(char c, FILE *file) {
 
         snrt_mutex_ttas_acquire(_snrt_printf_mutex_ptr);
         tohost = (uintptr_t)buf->hdr.syscall_mem;
+
+        // Trigger MSIP (machine software interrupt) on host (core 0)
+        *reg32(&__base_clint, CLINT_MSIP_REG_OFFSET) = 1;
         while (fromhost == 0);
         fromhost = 0;
         buf->hdr.size = 0;

--- a/host/drivers/cluster/offload_snitchCluster.c
+++ b/host/drivers/cluster/offload_snitchCluster.c
@@ -292,7 +292,8 @@ void wait_snitchCluster_busy(uint8_t clusterId) {
 }
 
 /**
- * @brief Wait for the cluster to return a value.
+ * @brief Wait for the cluster to return a value. The return value is written
+ * by the last core of the cluster.
  * The function busy waits until the cluster returns a non-zero value.
  *
  * @warning The return values must be non-zero, otherwise the function will busy wait forever!

--- a/host/drivers/driver.h
+++ b/host/drivers/driver.h
@@ -17,10 +17,6 @@
 #include "uart_apb/uart_apb.h"
 #endif
 
-#ifdef CHIMERA_DRIVER_UART_OPENTITAN
-#include "uart_opentitan/uart_opentitan.h"
-#endif
-
 #ifdef CHIMERA_DRIVER_CLINT32
 #include "clint32/clint32.h"
 #endif

--- a/host/runtime/CMakeLists.txt
+++ b/host/runtime/CMakeLists.txt
@@ -22,4 +22,5 @@ target_sources(runtime_host PRIVATE
   src/uart.c
   src/clint.c
   src/log.c
+  src/fll.c
 )

--- a/host/runtime/inc/clint.h
+++ b/host/runtime/inc/clint.h
@@ -124,6 +124,12 @@ void clint_sleep_until(uint32_t timer_idx, clint_mtime_t tgt_mtime);
  */
 void clint_sleep_ticks(uint32_t timer_idx, uint32_t ticks);
 
+/**
+ * @brief Default trap vector handler.
+ *
+ */
+void default_trap_vector(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/host/runtime/inc/fll.h
+++ b/host/runtime/inc/fll.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2022 ETH Zurich and University of Bologna
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Include Standard Libraries
+#include <stdint.h>
+
+// Include Target Specific Headers
+
+// Include Driver Headers
+
+// Include Runtime Headers
+
+/**
+ * @brief Calculate FLL parameters for a target frequency.
+ *
+ * @param target_freq Target frequency in Hz
+ * @param rtc_freq RTC frequency in Hz
+ * @param mult Output: FLL multiplier
+ * @param div Output: FLL divider (power of 2)
+ * @return 0 on success, -1 on error
+ */
+int calculate_fll_params(uint32_t target_freq, uint32_t rtc_freq, uint32_t *mult, uint32_t *div);
+
+/**
+ * @brief Configure FLLs to target frequency and reconfigure UART.
+ *
+ * @param target_freq Target frequency in Hz
+ * @param rtc_freq RTC frequency in Hz
+ * @return Actual configured frequency in Hz, or 0 on error
+ */
+uint32_t configure_fll(uint32_t target_freq, uint32_t rtc_freq);
+
+uint32_t restore_default_freq(uint32_t rtc_freq);

--- a/host/runtime/inc/util.h
+++ b/host/runtime/inc/util.h
@@ -104,6 +104,16 @@ static inline void set_mtie(int enable) {
 }
 
 /**
+ * @brief Gets the status pending interrupts in M-mode.
+ * @return 1 if M-mode pending interrupts are enabled, 0 otherwise.
+ */
+static inline int get_mip() {
+    uint32_t mip;
+    asm volatile("csrr %0, mip" : "=r"(mip)::"memory");
+    return mip;
+}
+
+/**
  * @brief Enables or disables M-mode global interrupts.
  * @param enable Set to 1 to enable, 0 to disable.
  */

--- a/host/runtime/src/clint.c
+++ b/host/runtime/src/clint.c
@@ -14,11 +14,26 @@
 
 // Include Runtime Headers
 #include "clint.h"
+#include "util.h"
 
 chi_interrupt_t default_clint_inst = {
     .api = &default_clint_api,
     .base = (uintptr_t)&__base_clint,
     .cfg = NULL,
 };
+
+// Prevent function removal by linker
+void default_trap_vector(void) {
+    // Check if it was a MSIP interrupt
+    uint32_t mip = get_mip();
+    if (mip & (1 << 3)) { // Check if it was a MSIP interrupt
+        // Clear the MSIP interrupt
+        *reg32(&__base_clint, CLINT_MSIP_REG_OFFSET) = 0;
+        return;
+    } else if (mip & (1 << 7)) { // Check if it was a MTIP interrupt
+        // Clear MTIP interrupt by disabling it temporarily
+        set_mtie(0);
+    }
+}
 
 #endif // CHIMERA_DRIVER_CLINT

--- a/host/runtime/src/fll.c
+++ b/host/runtime/src/fll.c
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2025 ETH Zurich and University of Bologna
+// SPDX-License-Identifier: Apache-2.0
+
+// Include Standard Libraries
+#include <stdint.h>
+#include <stddef.h>
+
+// Include Target Specific Headers
+#include "soc.h"
+
+// Include Driver Headers
+#include "driver.h"
+#include "sw/device/lib/dif/dif_gpio.h"
+
+// Include Runtime Headers
+#include "fll.h"
+#include "log.h"
+
+static const dif_gpio_t gpio = {
+    .base_addr = (volatile void *)&__base_gpio,
+};
+
+int calculate_fll_params(uint32_t target_freq, uint32_t rtc_freq, uint32_t *mult, uint32_t *div) {
+    if (!mult || !div || target_freq == 0 || rtc_freq == 0) return -1;
+
+    const uint32_t FMAX = 3300000000u; // 3.3 GHz (fits in 32-bit)
+    uint32_t denom = 2u * target_freq; // safe while target_freq <= ~2.147e9
+    if (denom == 0u) return -1;        // overflow guard
+
+    // Strict bound: Dout < limit
+    const uint32_t limit = FMAX / denom;
+    // Smallest Dout is 1 (when div=1). Need 1 < limit to have any valid Dout.
+    if (limit <= 1u) {
+        printf_log("Error: Target frequency too high for FLL\n");
+        return -1;
+    }
+
+    const uint32_t below = limit - 1u;
+    const uint32_t e = 31u - __builtin_clz(below); // e in [0..30] for our ranges
+    const uint32_t dout = 1u << e;
+
+    // Round multiplier for a closer Fout: mult ≈ target * dout / rtc
+    const uint32_t num = target_freq * dout;
+    uint32_t m = (num + rtc_freq / 2u) / rtc_freq;
+    if (m == 0u) m = 1u;
+
+    *div = e + 1u; // because Dout = 2^(div-1)
+    *mult = m;
+
+    // // Optional quick check:
+    // uint32_t fout = (rtc_freq * (*mult)) / (1u << (*div - 1));
+    // // printf_log("target=%u, div=%u, dout=%u, mult=%u, fout=%u\n", target_freq, *div, dout,
+    // *mult, fout); printf_log("Calculated FLL params: mult=%u, div=%u => fout=%u Hz (error: %+d
+    // ppm)\n",
+    //            *mult, *div, fout,
+    //            (int32_t)(((int64_t)fout - (int64_t)target_freq) * 1000000 / target_freq));
+
+    return 0;
+}
+
+uint32_t configure_fll(uint32_t target_freq, uint32_t rtc_freq) {
+    uint32_t mult, div;
+    dif_result_t result;
+
+    if (calculate_fll_params(target_freq, rtc_freq, &mult, &div) != 0) {
+        printf_log("Error: Cannot calculate FLL parameters for %u Hz\n", target_freq);
+        return 0;
+    }
+
+#if defined(TARGET_PLATFORM_CHIMERA_CONVOLVE)
+    result = dif_gpio_write(&gpio, 2, 1);
+    if (result != kDifOk) {
+        printf_log("Error: Cannot enable FLL bypass\n");
+        return 0;
+    }
+#endif
+    // Configure both FLLs (SOC and Cluster)
+    volatile uint32_t *fllPtr = getFllPtr(0);
+    initFll(fllPtr);
+    setFllFreq(fllPtr, mult, div);
+
+    fllPtr = getFllPtr(1);
+    initFll(fllPtr);
+    setFllFreq(fllPtr, mult, div);
+
+    // Delay for FLL lock
+    for (volatile int i = 0; i < 1000; i++);
+
+#if defined(TARGET_PLATFORM_CHIMERA_CONVOLVE)
+    // Disable FLL bypass
+    result = dif_gpio_write(&gpio, 2, 0);
+    if (result != kDifOk) {
+        printf_log("Error: Cannot disable FLL bypass\n");
+        return 0;
+    }
+#endif
+
+    // Relative Error = 1 / 128 = 0.78%
+    // uint32_t ref_time_inv = rtc_freq / 128; // 32768 // 128 = 256
+    // uint32_t core_freq_fll = clint_get_core_freq(rtc_freq, ref_time_inv);
+
+    // // Relative Error = 1 / 32768 = 30.5 ppm
+    uint32_t ref_time_inv = 1;
+    uint32_t core_freq_fll = clint_get_core_freq(rtc_freq, ref_time_inv);
+
+    // Reconfigure UART with new frequency
+    uart_config_t uart_cfg = default_uart_cfg;
+    uart_cfg.clk_freq_hz = core_freq_fll;
+    default_uart_inst.cfg = &uart_cfg;
+
+    if (iface_open(&default_uart_inst) != 0) {
+        return 0;
+    }
+
+    return core_freq_fll;
+}
+
+uint32_t restore_default_freq(uint32_t rtc_freq) {
+    dif_result_t result;
+
+#if defined(TARGET_PLATFORM_CHIMERA_CONVOLVE)
+    // Enable FLL bypass
+    result = dif_gpio_write(&gpio, 2, 1);
+    if (result != kDifOk) {
+        printf_log("Error: Cannot enable FLL bypass\n");
+        return 0;
+    }
+#endif
+
+    // Calculate default core frequency
+    // Relative Error = 1 / 128 = 0.78%
+    // Absolute Error = 78.125 kHz
+    uint32_t ref_time_inv = rtc_freq / 128; // 32768 // 128 = 256
+    uint32_t core_freq = clint_get_core_freq(rtc_freq, ref_time_inv);
+
+    // Reconfigure UART with default frequency
+    uart_config_t uart_cfg = default_uart_cfg;
+    uart_cfg.clk_freq_hz = core_freq;
+    default_uart_inst.cfg = &uart_cfg;
+
+    if (iface_open(&default_uart_inst) != 0) {
+        return 0;
+    }
+
+    return core_freq;
+}

--- a/host/runtime/src/fll.c
+++ b/host/runtime/src/fll.c
@@ -47,13 +47,15 @@ int calculate_fll_params(uint32_t target_freq, uint32_t rtc_freq, uint32_t *mult
     *div = e + 1u; // because Dout = 2^(div-1)
     *mult = m;
 
-    // // Optional quick check:
-    // uint32_t fout = (rtc_freq * (*mult)) / (1u << (*div - 1));
-    // // printf_log("target=%u, div=%u, dout=%u, mult=%u, fout=%u\n", target_freq, *div, dout,
-    // *mult, fout); printf_log("Calculated FLL params: mult=%u, div=%u => fout=%u Hz (error: %+d
-    // ppm)\n",
-    //            *mult, *div, fout,
-    //            (int32_t)(((int64_t)fout - (int64_t)target_freq) * 1000000 / target_freq));
+#ifdef TRACE
+    // Optional quick check:
+    uint32_t fout = (rtc_freq * (*mult)) / (1u << (*div - 1));
+    // printf_log("target=%u, div=%u, dout=%u, mult=%u, fout=%u\n", target_freq, *div, dout,
+    *mult, fout); printf_log("Calculated FLL params: mult=%u, div=%u => fout=%u Hz (error: %+d
+    ppm)\n",
+               *mult, *div, fout,
+               (int32_t)(((int64_t)fout - (int64_t)target_freq) * 1000000 / target_freq));
+#endif
 
     return 0;
 }
@@ -100,11 +102,7 @@ uint32_t configure_fll(uint32_t target_freq, uint32_t rtc_freq) {
     }
 #endif
 
-    // Relative Error = 1 / 128 = 0.78%
-    // uint32_t ref_time_inv = rtc_freq / 128; // 32768 // 128 = 256
-    // uint32_t core_freq_fll = clint_get_core_freq(rtc_freq, ref_time_inv);
-
-    // // Relative Error = 1 / 32768 = 30.5 ppm
+    // Relative Error = 1 / 32768 = 30.5 ppm
     uint32_t ref_time_inv = 1;
     uint32_t core_freq_fll = clint_get_core_freq(rtc_freq, ref_time_inv);
 

--- a/host/runtime/src/fll.c
+++ b/host/runtime/src/fll.c
@@ -59,6 +59,11 @@ int calculate_fll_params(uint32_t target_freq, uint32_t rtc_freq, uint32_t *mult
 }
 
 uint32_t configure_fll(uint32_t target_freq, uint32_t rtc_freq) {
+#ifndef CHIMERA_DRIVER_FLL
+    printf_log("Error: FLL driver not included in build\n");
+    return -1;
+#else
+
     uint32_t mult, div;
     dif_result_t result;
 
@@ -113,9 +118,15 @@ uint32_t configure_fll(uint32_t target_freq, uint32_t rtc_freq) {
     }
 
     return core_freq_fll;
+#endif
 }
 
 uint32_t restore_default_freq(uint32_t rtc_freq) {
+#ifndef CHIMERA_DRIVER_FLL
+    printf_log("Error: FLL driver not included in build\n");
+    return -1;
+#else
+
     dif_result_t result;
 
 #if defined(TARGET_PLATFORM_CHIMERA_CONVOLVE)
@@ -143,4 +154,5 @@ uint32_t restore_default_freq(uint32_t rtc_freq) {
     }
 
     return core_freq;
+#endif
 }

--- a/targets/chimera-convolve/chimera.cfg
+++ b/targets/chimera-convolve/chimera.cfg
@@ -20,11 +20,11 @@ riscv set_command_timeout_sec 120
 
 # riscv set_prefer_sba off
 
-# Exit when debugger detaches
-# $_TARGETNAME configure -event gdb-detach {
-#     echo "GDB detached; ending debugging session."
-#     shutdown
-# }
+# Set SCRATCH0 to 2 after reset to indicate interactive mode
+$_TARGETNAME configure -event reset-end {
+    echo "Setting SCRATCH0 to 2 for interactive test mode."
+    mww 0x03000000 0x00000002
+}
 
 init
 halt

--- a/targets/chimera-convolve/inc/test.h
+++ b/targets/chimera-convolve/inc/test.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2022 ETH Zurich and University of Bologna
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Include Standard Libraries
+#include <stdint.h>
+
+// Include Target Specific Headers
+
+// Include Driver Headers
+
+// Include Runtime Headers
+typedef struct __attribute__((packed)) {
+    uint32_t errors;
+    uint32_t runtime_cycles;
+    uint32_t ops_per_cycle;  // Operations per 1M cycles
+    uint32_t ops_per_second; // 1M Operations per s
+} test_cluster_result_t;
+
+typedef struct __attribute__((packed)) {
+    volatile int32_t repetitions;
+    volatile test_cluster_result_t *result;
+    volatile void *args;
+} test_cluster_args_t;
+
+typedef enum {
+    TEST_MODE_AUTOMATIC = 0,
+    TEST_MODE_DUTCTL = 1,
+    TEST_MODE_INTERACTIVE = 2,
+} test_mode_t;
+
+typedef struct {
+    char *name; // Name of the test
+    test_mode_t mode;
+    uint32_t default_frequency_mhz; // Default frequency in MHz in automatic mode (-1 to skip FLL)
+    uint32_t default_repetitions;   // Default number of repetitions in automatic mode
+    uint32_t timeout;               // Timeout in milliseconds
+    uint8_t clusterId;              // Cluster ID to run the test on
+    void *stack_start;              // Start address of the stack
+    uint32_t *stack_sizes;          // Stack sizes for each core in the cluster
+    void *function_test;            // Test function to execute on the cluster
+    void *function_interrupt;       // Interrupt handler function
+    test_cluster_args_t *args;      // Arguments to pass to the test function
+} test_cluster_cfg_t;
+
+/**
+ * @brief Execute test on specified cluster.
+ *
+ * Make sure that all GPIOs are initialized properly
+ */
+int test_cluster(test_cluster_cfg_t *test_cfg);

--- a/targets/chimera-convolve/inc/test.h
+++ b/targets/chimera-convolve/inc/test.h
@@ -36,12 +36,14 @@ typedef struct {
     uint32_t default_frequency_mhz; // Default frequency in MHz in automatic mode (-1 to skip FLL)
     uint32_t default_repetitions;   // Default number of repetitions in automatic mode
     uint32_t timeout;               // Timeout in milliseconds
-    uint8_t clusterId;              // Cluster ID to run the test on
-    void *stack_start;              // Start address of the stack
-    uint32_t *stack_sizes;          // Stack sizes for each core in the cluster
-    void *function_test;            // Test function to execute on the cluster
-    void *function_interrupt;       // Interrupt handler function
-    test_cluster_args_t *args;      // Arguments to pass to the test function
+    uint32_t clusters;              // Number of clusters to run the test on
+    uint8_t clusterIds[_chimera_numClusters];    // Cluster IDs to run the test on
+    void *stack_start[_chimera_numClusters];     // Start addresses of the stack
+    uint32_t *stack_sizes[_chimera_numClusters]; // Stack sizes for each cluster and each core in
+                                                 // the cluster
+    void *function_test;                         // Test function to execute on the cluster
+    void *function_interrupt;                    // Interrupt handler function
+    test_cluster_args_t *args[_chimera_numClusters]; // Arguments to pass to the test function
 } test_cluster_cfg_t;
 
 /**

--- a/targets/chimera-convolve/src/crt0.S
+++ b/targets/chimera-convolve/src/crt0.S
@@ -131,7 +131,7 @@ _trap_handler_wrap:
 
 .weak trap_vector
 trap_vector:
-    j trap_vector
+    j default_trap_vector
 
 
 .section .cbss, "aw", @nobits

--- a/targets/chimera-convolve/src/test.c
+++ b/targets/chimera-convolve/src/test.c
@@ -62,8 +62,13 @@ int test_cluster(test_cluster_cfg_t *test_cfg) {
     do {
         if (test_cfg->mode == TEST_MODE_DUTCTL) {
             // In DUTCTL mode, run once with default parameters
-            test_cfg->args->repetitions = scratch[1]; // e.g. 1
-            printf("@dutctl:dutmeas:cfg_repetitions:%d\r\n", test_cfg->args->repetitions);
+            for (int id = 0; id < test_cfg->clusters; id++) {
+                uint8_t clusterId = test_cfg->clusterIds[id];
+                test_cluster_args_t *arg = test_cfg->args[id];
+                arg->repetitions = scratch[1];
+                printf("@dutctl:dutmeas:cfg_repetitions_%d:%d\r\n", clusterId,
+                       test_cfg->args[id]->repetitions);
+            }
         } else if (test_cfg->mode == TEST_MODE_INTERACTIVE) {
             printf_log("Enter number of repetitions (default 1): ");
             fflush(stdout);
@@ -78,11 +83,17 @@ int test_cluster(test_cluster_cfg_t *test_cfg) {
                 repetitions = atoi(input_buffer);
             }
             printf("%d\n", repetitions);
-            test_cfg->args->repetitions = repetitions;
+            for (int id = 0; id < test_cfg->clusters; id++) {
+                test_cluster_args_t *arg = test_cfg->args[id];
+                arg->repetitions = repetitions;
+            }
         } else {
             // In other modes, use default of 1
             printf_log("Using repetitions = %d\n", test_cfg->default_repetitions);
-            test_cfg->args->repetitions = test_cfg->default_repetitions;
+            for (int id = 0; id < test_cfg->clusters; id++) {
+                test_cluster_args_t *arg = test_cfg->args[id];
+                arg->repetitions = test_cfg->default_repetitions;
+            }
         }
 
         if (test_cfg->mode == TEST_MODE_DUTCTL) {
@@ -150,28 +161,27 @@ int test_cluster(test_cluster_cfg_t *test_cfg) {
         uint32_t actual_freq = core_freq;
         printf_log("Note: FLL configuration only available on ASIC target\n");
 #endif
-
         // Setup cluster
-        if (test_cfg->mode != TEST_MODE_DUTCTL) {
-            printf_log("----------------------------------------\n");
-            printf_log("Setting up cluster %d...\n", test_cfg->clusterId);
-            printf_log("----------------------------------------\n");
-        }
-
-        test_cluster_args_t *arg = test_cfg->args;
-
-        void *stack_cluster_ptr[NUM_CLUSTER_CORES];
-        generate_snitchCluster_SPs(test_cfg->clusterId, test_cfg->stack_start,
-                                   test_cfg->stack_sizes, stack_cluster_ptr);
-
         setup_snitchCluster_interruptHandler(test_cfg->function_interrupt);
+        void *stack_cluster_ptr[test_cfg->clusters][NUM_CLUSTER_CORES];
+        for (int id = 0; id < test_cfg->clusters; id++) {
+            uint8_t clusterId = test_cfg->clusterIds[id];
+            if (test_cfg->mode != TEST_MODE_DUTCTL) {
+                printf_log("----------------------------------------\n");
+                printf_log("Setting up cluster %d...\n", clusterId);
+                printf_log("----------------------------------------\n");
+            }
 
-        set_snitchCluster_clockGating(test_cfg->clusterId, 0);
+            generate_snitchCluster_SPs(clusterId, test_cfg->stack_start[id],
+                                       test_cfg->stack_sizes[id], stack_cluster_ptr[id]);
 
-        set_snitchCluster_reset(test_cfg->clusterId, 1);
-        for (volatile int i = 0; i < 10; i++);
-        set_snitchCluster_reset(test_cfg->clusterId, 0);
-        for (volatile int i = 0; i < 1000; i++);
+            set_snitchCluster_clockGating(clusterId, 0);
+
+            set_snitchCluster_reset(clusterId, 1);
+            for (volatile int i = 0; i < 10; i++);
+            set_snitchCluster_reset(clusterId, 0);
+            for (volatile int i = 0; i < 1000; i++);
+        }
 
         // Record start time
         clint_mtime_t start_time = clint_get_mtime();
@@ -190,14 +200,22 @@ int test_cluster(test_cluster_cfg_t *test_cfg) {
         // Disable interrupts
         set_mie(0);
 
-        offload_snitchCluster(test_cfg->function_test, (void *)arg, stack_cluster_ptr,
-                              test_cfg->clusterId);
+        for (int id = 0; id < test_cfg->clusters; id++) {
+            test_cluster_args_t *arg = test_cfg->args[id];
+            offload_snitchCluster(test_cfg->function_test, (void *)arg, stack_cluster_ptr[id],
+                                  test_cfg->clusterIds[id]);
+        }
         // Enable interrupts
         set_mie(1);
 
         // Handle tohost/fromhost communication with timeout
         int timed_out = 0;
-        while (snitchCluster_busy(test_cfg->clusterId)) {
+        int done = 0;
+        while (done != test_cfg->clusters && !timed_out) {
+            done = 0;
+            for (int id = 0; id < test_cfg->clusters; id++) {
+                done += snitchCluster_busy(test_cfg->clusterIds[id]) ? 0 : 1;
+            }
             // Check for timeout
             clint_mtime_t current_time = clint_get_mtime();
             if (clint_mtime_less_than(deadline, current_time)) {
@@ -233,47 +251,53 @@ int test_cluster(test_cluster_cfg_t *test_cfg) {
             clint_sleep_ticks(0, 10);
         }
 
-        retVal = 0;
-        if (!timed_out) {
-            retVal = wait_snitchCluster_return(test_cfg->clusterId);
-            retVal = retVal >> 1;
-        }
+        for (int id = 0; id < test_cfg->clusters; id++) {
+            uint8_t clusterId = test_cfg->clusterIds[id];
+            test_cluster_args_t *arg = test_cfg->args[id];
+            retVal = 0;
+            if (!timed_out) {
+                retVal = wait_snitchCluster_return(test_cfg->clusterIds[id]);
+                retVal = retVal >> 1;
+            }
 
-        set_snitchCluster_clockGating(test_cfg->clusterId, 1);
+            set_snitchCluster_clockGating(test_cfg->clusterIds[id], 1);
 
-        // Calculate and display metrics
-        if (test_cfg->mode != TEST_MODE_DUTCTL) {
-            printf_log("----------------------------------------\n");
-            printf_log("Execution Results\n");
-            printf_log("----------------------------------------\n");
-            printf_log("Return value: 0x%08x (%d errors)\n", retVal, retVal);
-        }
+            // Calculate and display metrics
+            if (test_cfg->mode != TEST_MODE_DUTCTL) {
+                printf_log("----------------------------------------\n");
+                printf_log("Execution Results from cluster %d\n", clusterId);
+                printf_log("----------------------------------------\n");
+                printf_log("Return value: 0x%08x (%d errors)\n", retVal, retVal);
+            }
 
-        if (!timed_out) {
-            // Calculate operations per second
-            // Ops in Op/cycle * 1e6
-            // Frequency in Hz
-            // Ops per cycle in  Op / cycle * 1e6 * 1e-3 * Hz * 1e-3 = Op/s
-            uint32_t kops_per_sec = ((arg->result)->ops_per_cycle / 10000) * (actual_freq / 100000);
+            if (!timed_out) {
+                // Calculate operations per second
+                // Ops in Op/cycle * 1e6
+                // Frequency in Hz
+                // Ops per cycle in  Op / cycle * 1e6 * 1e-3 * Hz * 1e-3 = Op/s
+                uint32_t kops_per_sec =
+                    ((arg->result)->ops_per_cycle / 10000) * (actual_freq / 100000);
 
-            printf(" arg->ops_per_cycle = %u\n", (arg->result)->ops_per_cycle);
-            printf(" actual_freq = %u\n", actual_freq);
-            printf(" kops_per_sec = %u\n", kops_per_sec);
+                // printf(" arg->ops_per_cycle = %u\n", (arg->result)->ops_per_cycle);
+                // printf(" actual_freq = %u\n", actual_freq);
+                // printf(" kops_per_sec = %u\n", kops_per_sec);
 
-            if (test_cfg->mode == TEST_MODE_DUTCTL) {
-                printf("@dutctl:dutmeas:meas_ops_per_cycle:%u.%06u\n",
-                       (arg->result)->ops_per_cycle / 1000000,
-                       (arg->result)->ops_per_cycle % 1000000);
-                // MOp/s
-                printf("@dutctl:dutmeas:meas_ops_per_second:%u.%03u\n", kops_per_sec / 1000,
-                       kops_per_sec % 1000);
-                printf("@dutctl:dutmeas:meas_runtime_cycles:%u\n", (arg->result)->runtime_cycles);
-                printf("@dutctl:dutmeas:meas_errors:%u\n", (arg->result)->errors);
-            } else {
-                printf_log("Op/Cycle: %u.%06u\n", (arg->result)->ops_per_cycle / 1000000,
+                if (test_cfg->mode == TEST_MODE_DUTCTL) {
+                    printf("@dutctl:dutmeas:meas_ops_per_cycle_%d:%u.%06u\n", clusterId,
+                           (arg->result)->ops_per_cycle / 1000000,
                            (arg->result)->ops_per_cycle % 1000000);
-                printf_log("Op/s: %u.%03u M\n", kops_per_sec / 1000, kops_per_sec % 1000);
-                printf_log("Runtime Cycles: %u\n", (arg->result)->runtime_cycles);
+                    // MOp/s
+                    printf("@dutctl:dutmeas:meas_ops_per_second_%d:%u.%03u\n", clusterId,
+                           kops_per_sec / 1000, kops_per_sec % 1000);
+                    printf("@dutctl:dutmeas:meas_runtime_cycles_%d:%u\n", clusterId,
+                           (arg->result)->runtime_cycles);
+                    printf("@dutctl:dutmeas:meas_errors_%d:%u\n", clusterId, (arg->result)->errors);
+                } else {
+                    printf_log("Op/Cycle: %u.%06u\n", (arg->result)->ops_per_cycle / 1000000,
+                               (arg->result)->ops_per_cycle % 1000000);
+                    printf_log("Op/s: %u.%03u M\n", kops_per_sec / 1000, kops_per_sec % 1000);
+                    printf_log("Runtime Cycles: %u\n", (arg->result)->runtime_cycles);
+                }
             }
         }
 

--- a/targets/chimera-convolve/src/test.c
+++ b/targets/chimera-convolve/src/test.c
@@ -1,0 +1,310 @@
+
+// SPDX-FileCopyrightText: 2024 ETH Zurich and University of Bologna
+// SPDX-License-Identifier: Apache-2.0
+
+// Include Standard Libraries
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Include Target Specific Headers
+#include "soc.h"
+#include "test.h"
+
+// Include Driver Headers
+#include "driver.h"
+#include "sw/device/lib/dif/dif_gpio.h"
+
+// Include Runtime Headers
+#include "log.h"
+#include "fll.h"
+#include "util.h"
+#include "clint.h"
+
+// Import HAL Headers
+
+extern uintptr_t volatile tohost, fromhost;
+
+int test_cluster(test_cluster_cfg_t *test_cfg) {
+    dif_result_t result;
+    uint32_t retVal = 0;
+
+    // Read the RTC frequency from a hardware register
+    uint32_t rtc_freq = *reg32(&__base_regs, CHESHIRE_RTC_FREQ_REG_OFFSET);
+
+#if defined(HARDWARE_BACKEND_ASIC)
+    restore_default_freq(rtc_freq);
+
+    // Calculate the initial core frequency from the RTC frequency
+    // Relative Error = 1 / 128 = 0.78%
+    // Absolute Error = 78.125 kHz
+    uint32_t ref_time_inv = rtc_freq / 128; // 32768 // 128 = 256
+    uint32_t core_freq = clint_get_core_freq(rtc_freq, ref_time_inv);
+#else
+    uint32_t core_freq = 500000000; // 500 MHz for RTL
+    printf("Assuming core frequency: %u.%03u MHz\n", (core_freq / 1000000), (core_freq % 1000000));
+#endif
+
+    volatile uint32_t *scratch =
+        (volatile uint32_t *)(&__base_regs + CHESHIRE_SCRATCH_0_REG_OFFSET);
+
+    if (test_cfg->mode != TEST_MODE_DUTCTL) {
+        printf("\n\n");
+        printf_log("========================================\n");
+        printf_log("Chimera %s Test \n", test_cfg->name);
+        printf_log("========================================\n");
+        printf_log("Initial frequency: %u.%03u MHz\n", (core_freq / 1000000),
+                   (core_freq % 1000000));
+    }
+
+    // Buffer to hold run again
+    char input_buffer[32];
+    do {
+        if (test_cfg->mode == TEST_MODE_DUTCTL) {
+            // In DUTCTL mode, run once with default parameters
+            test_cfg->args->repetitions = scratch[1]; // e.g. 1
+            printf("@dutctl:dutmeas:cfg_repetitions:%d\r\n", test_cfg->args->repetitions);
+        } else if (test_cfg->mode == TEST_MODE_INTERACTIVE) {
+            printf_log("Enter number of repetitions (default 1): ");
+            fflush(stdout);
+
+            if (fgets(input_buffer, sizeof(input_buffer), stdin) == NULL) {
+                printf("\n");
+                printf_log("Error reading input\n");
+                return -1;
+            }
+            int repetitions = 1;
+            if (strlen(input_buffer) > 1) {
+                repetitions = atoi(input_buffer);
+            }
+            printf("%d\n", repetitions);
+            test_cfg->args->repetitions = repetitions;
+        } else {
+            // In other modes, use default of 1
+            printf_log("Using repetitions = %d\n", test_cfg->default_repetitions);
+            test_cfg->args->repetitions = test_cfg->default_repetitions;
+        }
+
+        if (test_cfg->mode == TEST_MODE_DUTCTL) {
+            uint32_t core_mV = scratch[2]; // e.g. 900
+            printf("@dutctl:dutmeas:cfg_core_mV:%d\r\n", core_mV);
+            printf("@dutctl:psuctl:%d.%d:0:E36312A_1:1\r\n", core_mV / 1000, core_mV % 1000);
+        }
+
+#if defined(HARDWARE_BACKEND_ASIC)
+        int target_freq_mhz = 0;
+        if (test_cfg->mode == TEST_MODE_DUTCTL) {
+            // In DUTCTL mode, read target frequency from scratch register
+            target_freq_mhz = scratch[3]; // e.g. 170
+            printf("@dutctl:dutmeas:cfg_fll_MHz:%d\r\n", target_freq_mhz);
+        } else if (test_cfg->mode == TEST_MODE_INTERACTIVE) {
+            // Ask user for target frequency
+            printf_log(
+                "Enter target frequency in MHz (10-1000, or -1 to skip FLL configuration): ");
+            fflush(stdout);
+
+            if (fgets(input_buffer, sizeof(input_buffer), stdin) == NULL) {
+                printf("\n");
+                printf_log("Error reading input\n");
+                return -1;
+            }
+
+            target_freq_mhz = atoi(input_buffer);
+            printf("%d\n", target_freq_mhz);
+        } else {
+            // In other modes, default to 200 MHz
+            printf_log("Using target frequency = %d MHz\n", test_cfg->default_frequency_mhz);
+            target_freq_mhz = test_cfg->default_frequency_mhz;
+        }
+
+        uint32_t actual_freq = core_freq;
+
+        if (target_freq_mhz == -1) {
+            printf_log("Skipping FLL configuration, using external clock\n");
+        } else if (target_freq_mhz < 10 || target_freq_mhz > 1000) {
+            printf_log("Error: Frequency out of range (10-1000 MHz)\n");
+            continue;
+        } else {
+            if (test_cfg->mode != TEST_MODE_DUTCTL) {
+                printf_log("Configuring system to %d MHz...\n", target_freq_mhz);
+            }
+
+            uint32_t target_freq = target_freq_mhz * 1000000;
+            actual_freq = configure_fll(target_freq, rtc_freq);
+            if (actual_freq == 0) {
+                printf_log("Error: Failed to configure FLL\n");
+                return -1;
+            }
+            if (test_cfg->mode != TEST_MODE_DUTCTL) {
+                printf_log("FLL configured successfully!\n");
+                printf_log("Actual frequency: %u.%03u MHz\n", (actual_freq / 1000000),
+                           (actual_freq % 1000000));
+            }
+            if (test_cfg->mode == TEST_MODE_DUTCTL) {
+                printf("@dutctl:dutmeas:meas_fll_MHz:%d.%03d\r\n", (actual_freq / 1000000),
+                       (actual_freq % 1000000));
+            }
+        }
+
+#else
+        uint32_t actual_freq = core_freq;
+        printf_log("Note: FLL configuration only available on ASIC target\n");
+#endif
+
+        // Setup cluster
+        if (test_cfg->mode != TEST_MODE_DUTCTL) {
+            printf_log("----------------------------------------\n");
+            printf_log("Setting up cluster %d...\n", test_cfg->clusterId);
+            printf_log("----------------------------------------\n");
+        }
+
+        test_cluster_args_t *arg = test_cfg->args;
+
+        void *stack_cluster_ptr[NUM_CLUSTER_CORES];
+        generate_snitchCluster_SPs(test_cfg->clusterId, test_cfg->stack_start,
+                                   test_cfg->stack_sizes, stack_cluster_ptr);
+
+        setup_snitchCluster_interruptHandler(test_cfg->function_interrupt);
+
+        set_snitchCluster_clockGating(test_cfg->clusterId, 0);
+
+        set_snitchCluster_reset(test_cfg->clusterId, 1);
+        for (volatile int i = 0; i < 10; i++);
+        set_snitchCluster_reset(test_cfg->clusterId, 0);
+        for (volatile int i = 0; i < 1000; i++);
+
+        // Record start time
+        clint_mtime_t start_time = clint_get_mtime();
+        uint32_t timeout_ticks = rtc_freq * test_cfg->timeout / 1000;
+        clint_mtime_t deadline = start_time;
+        deadline.low += timeout_ticks;
+        if (deadline.low < start_time.low) {
+            deadline.high += 1; // Handle overflow
+        }
+
+        if (test_cfg->mode == TEST_MODE_DUTCTL) {
+            // For 500 iterations, computation should last at least 1s even at 400MHz
+            printf("@dutctl:psumeas:meas_core_V:500:E36312A_1:1\r\n");
+        }
+
+        // Disable interrupts
+        set_mie(0);
+
+        offload_snitchCluster(test_cfg->function_test, (void *)arg, stack_cluster_ptr,
+                              test_cfg->clusterId);
+        // Enable interrupts
+        set_mie(1);
+
+        // Handle tohost/fromhost communication with timeout
+        int timed_out = 0;
+        while (snitchCluster_busy(test_cfg->clusterId)) {
+            // Check for timeout
+            clint_mtime_t current_time = clint_get_mtime();
+            if (clint_mtime_less_than(deadline, current_time)) {
+                printf_log("Error: Cluster execution timed out after %u ms\n", test_cfg->timeout);
+                if (test_cfg->mode == TEST_MODE_DUTCTL) {
+                    printf("@dutctl:dutmeas:meas_errors:-1\n");
+                }
+                timed_out = 1;
+                break;
+            }
+
+            // Wait for tohost to be set by the device
+            if (tohost != 0) {
+                volatile uint32_t syscall_addr = tohost;
+
+                // Acknowledge tohost
+                tohost = 0;
+
+                // Cluster does tohost = (uintptr_t)buf->hdr.syscall_mem;
+                uint32_t *syscall_mem = (uint32_t *)syscall_addr;
+
+                if (syscall_mem[0] == 64) { // sys_write
+                    fwrite((const void *)syscall_mem[2], 1, syscall_mem[3], (FILE *)syscall_mem[1]);
+                    fflush((FILE *)syscall_mem[1]);
+                } else {
+                    printf_log("Unknown syscall: %u\n", syscall_mem[0]);
+                }
+
+                // Notify cluster that syscall is done
+                fromhost = syscall_addr;
+            }
+            // Enter low-power mode until next interrupt
+            clint_sleep_ticks(0, 10);
+        }
+
+        retVal = 0;
+        if (!timed_out) {
+            retVal = wait_snitchCluster_return(test_cfg->clusterId);
+            retVal = retVal >> 1;
+        }
+
+        set_snitchCluster_clockGating(test_cfg->clusterId, 1);
+
+        // Calculate and display metrics
+        if (test_cfg->mode != TEST_MODE_DUTCTL) {
+            printf_log("----------------------------------------\n");
+            printf_log("Execution Results\n");
+            printf_log("----------------------------------------\n");
+            printf_log("Return value: 0x%08x (%d errors)\n", retVal, retVal);
+        }
+
+        if (!timed_out) {
+            // Calculate operations per second
+            // Ops in Op/cycle * 1e6
+            // Frequency in Hz
+            // Ops per cycle in  Op / cycle * 1e6 * 1e-3 * Hz * 1e-3 = Op/s
+            uint32_t kops_per_sec = ((arg->result)->ops_per_cycle / 10000) * (actual_freq / 100000);
+
+            printf(" arg->ops_per_cycle = %u\n", (arg->result)->ops_per_cycle);
+            printf(" actual_freq = %u\n", actual_freq);
+            printf(" kops_per_sec = %u\n", kops_per_sec);
+
+            if (test_cfg->mode == TEST_MODE_DUTCTL) {
+                printf("@dutctl:dutmeas:meas_ops_per_cycle:%u.%06u\n",
+                       (arg->result)->ops_per_cycle / 1000000,
+                       (arg->result)->ops_per_cycle % 1000000);
+                // MOp/s
+                printf("@dutctl:dutmeas:meas_ops_per_second:%u.%03u\n", kops_per_sec / 1000,
+                       kops_per_sec % 1000);
+                printf("@dutctl:dutmeas:meas_runtime_cycles:%u\n", (arg->result)->runtime_cycles);
+                printf("@dutctl:dutmeas:meas_errors:%u\n", (arg->result)->errors);
+            } else {
+                printf_log("Op/Cycle: %u.%06u\n", (arg->result)->ops_per_cycle / 1000000,
+                           (arg->result)->ops_per_cycle % 1000000);
+                printf_log("Op/s: %u.%03u M\n", kops_per_sec / 1000, kops_per_sec % 1000);
+                printf_log("Runtime Cycles: %u\n", (arg->result)->runtime_cycles);
+            }
+        }
+
+#if defined(HARDWARE_BACKEND_ASIC)
+        // Restore default frequency if FLL was used
+        if (target_freq_mhz != -1 && target_freq_mhz >= 10 && target_freq_mhz <= 1000) {
+            uint32_t restored_freq = restore_default_freq(rtc_freq);
+            if (test_cfg->mode != TEST_MODE_DUTCTL) {
+                printf_log("Restored to %u.%03u MHz\n", (restored_freq / 1000000),
+                           (restored_freq % 1000000));
+            }
+        }
+#endif
+
+        if (test_cfg->mode == TEST_MODE_INTERACTIVE) {
+            printf_log("========================================\n");
+            printf_log("Run again? (y/n): ");
+            fflush(stdout);
+            if (fgets(input_buffer, 2, stdin) == NULL ||
+                (input_buffer[0] != 'y' && input_buffer[0] != 'Y')) {
+                break;
+            }
+            printf("%s\n", input_buffer);
+        } else {
+            break;
+        }
+
+        if (timed_out) {
+            return -1;
+        }
+    } while (1);
+
+    return retVal;
+}

--- a/targets/chimera-host/src/crt0.S
+++ b/targets/chimera-host/src/crt0.S
@@ -130,4 +130,4 @@ _trap_handler_wrap:
 
 .weak trap_vector
 trap_vector:
-    j trap_vector
+    j default_trap_vector

--- a/targets/chimera-open/src/crt0.S
+++ b/targets/chimera-open/src/crt0.S
@@ -131,7 +131,7 @@ _trap_handler_wrap:
 
 .weak trap_vector
 trap_vector:
-    j trap_vector
+    j default_trap_vector
 
 .section .cbss, "aw", @nobits
 

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: 2024 ETH Zurich and University of Bologna
-# SPDX-License-Identifier: Apache-2.0
-
-add_subdirectory(returnZero)
-add_subdirectory(printf)
-add_subdirectory(alloc)

--- a/tests/snitchCluster/matmul/src_host/test_host.c
+++ b/tests/snitchCluster/matmul/src_host/test_host.c
@@ -16,6 +16,7 @@
 // Include Runtime Headers
 #include "log.h"
 #include "util.h"
+#include "clint.h"
 
 // Import HAL Headers
 
@@ -66,7 +67,12 @@ int main(void) {
 
     printf_log("Waiting for cluster to finish...\n");
 
+    // Disable interrupts
+    set_mie(0);
     offload_snitchCluster(testReturn, NULL, stack_cluster_ptr, CLUSTER);
+
+    // Enable interrupts
+    set_mie(1);
 
     // Handle tohost/fromhost communication
     while (snitchCluster_busy(CLUSTER)) {
@@ -94,6 +100,9 @@ int main(void) {
             // Notify cluster that syscall is done
             fromhost = syscall_addr;
         }
+
+        // Enter low-power mode until next interrupt
+        clint_sleep_ticks(0, 10);
     }
 
     uint32_t retVal = wait_snitchCluster_return(CLUSTER);

--- a/tests/snitchCluster/matmul/src_host/test_host.c
+++ b/tests/snitchCluster/matmul/src_host/test_host.c
@@ -20,8 +20,8 @@
 
 // Import HAL Headers
 
-#define CLUSTER 4
-#define STACK_ADDRESS (_chimera_clusterBase[CLUSTER] + 0x20000 - 1)
+#define CLUSTER1 4
+#define STACK_ADDRESS (_chimera_clusterBase[CLUSTER1] + 0x20000 - 1)
 
 extern uintptr_t volatile tohost, fromhost;
 
@@ -55,27 +55,27 @@ int main(void) {
 #endif
 
     void *stack_cluster_ptr[NUM_CLUSTER_CORES];
-    generate_snitchCluster_SPs_uniform(CLUSTER, (void *)STACK_ADDRESS, 0x2000, stack_cluster_ptr);
+    generate_snitchCluster_SPs_uniform(CLUSTER1, (void *)STACK_ADDRESS, 0x2000, stack_cluster_ptr);
 
     setup_snitchCluster_interruptHandler(clusterInterruptHandler);
 
-    set_snitchCluster_clockGating(CLUSTER, 0);
+    set_snitchCluster_clockGating(CLUSTER1, 0);
 
-    set_snitchCluster_reset(CLUSTER, 1);
+    set_snitchCluster_reset(CLUSTER1, 1);
     for (volatile int i = 0; i < 10; i++);
-    set_snitchCluster_reset(CLUSTER, 0);
+    set_snitchCluster_reset(CLUSTER1, 0);
 
     printf_log("Waiting for cluster to finish...\n");
 
     // Disable interrupts
     set_mie(0);
-    offload_snitchCluster(testReturn, NULL, stack_cluster_ptr, CLUSTER);
+    offload_snitchCluster(testReturn, NULL, stack_cluster_ptr, CLUSTER1);
 
     // Enable interrupts
     set_mie(1);
 
     // Handle tohost/fromhost communication
-    while (snitchCluster_busy(CLUSTER)) {
+    while (snitchCluster_busy(CLUSTER1)) {
         // Wait for tohost to be set by the device
         if (tohost != 0) {
             volatile uint32_t syscall_addr = tohost;
@@ -105,10 +105,10 @@ int main(void) {
         clint_sleep_ticks(0, 10);
     }
 
-    uint32_t retVal = wait_snitchCluster_return(CLUSTER);
+    uint32_t retVal = wait_snitchCluster_return(CLUSTER1);
     retVal = retVal >> 1;
 
-    set_snitchCluster_clockGating(CLUSTER, 1);
+    set_snitchCluster_clockGating(CLUSTER1, 1);
 
     printf_log("Returned from cluster: 0x%08x (%d)\n", retVal, retVal);
 

--- a/tests/snitchCluster/simpleOffload/src_host/test_host.c
+++ b/tests/snitchCluster/simpleOffload/src_host/test_host.c
@@ -18,8 +18,8 @@
 
 // Import HAL Headers
 
-#define CLUSTER 0
-#define STACK_ADDRESS (_chimera_clusterBase[CLUSTER] + 0x20000 - 1)
+#define CLUSTER1 0
+#define STACK_ADDRESS (_chimera_clusterBase[CLUSTER1] + 0x20000 - 1)
 
 static offloadArgs_t offloadArgs = {.value = 0xdeadbeef};
 
@@ -41,22 +41,22 @@ int main(void) {
 #endif
 
     void *stack_cluster_ptr[NUM_CLUSTER_CORES];
-    generate_snitchCluster_SPs_uniform(CLUSTER, (void *)STACK_ADDRESS, 0x2000, stack_cluster_ptr);
+    generate_snitchCluster_SPs_uniform(CLUSTER1, (void *)STACK_ADDRESS, 0x2000, stack_cluster_ptr);
 
     setup_snitchCluster_interruptHandler(clusterInterruptHandler);
 
-    set_snitchCluster_clockGating(CLUSTER, 0);
+    set_snitchCluster_clockGating(CLUSTER1, 0);
 
-    set_snitchCluster_reset(CLUSTER, 1);
+    set_snitchCluster_reset(CLUSTER1, 1);
     for (volatile int i = 0; i < 10; i++);
-    set_snitchCluster_reset(CLUSTER, 0);
+    set_snitchCluster_reset(CLUSTER1, 0);
 
     printf_log("Waiting for cluster to finish...\n");
 
-    offload_snitchCluster(testReturn, &offloadArgs, stack_cluster_ptr, CLUSTER);
-    uint32_t retVal = wait_snitchCluster_return(CLUSTER);
+    offload_snitchCluster(testReturn, &offloadArgs, stack_cluster_ptr, CLUSTER1);
+    uint32_t retVal = wait_snitchCluster_return(CLUSTER1);
 
-    set_snitchCluster_clockGating(CLUSTER, 1);
+    set_snitchCluster_clockGating(CLUSTER1, 1);
 
     printf("Returned value: 0x%08x (%d)\n", retVal, retVal);
     printf("Expected value: 0x%08x\n", (TESTVAL | 0x000000001));

--- a/tests/snitchCluster/snrt/src_host/test_host.c
+++ b/tests/snitchCluster/snrt/src_host/test_host.c
@@ -20,8 +20,8 @@
 
 // Import HAL Headers
 
-#define CLUSTER 4
-#define STACK_ADDRESS (_chimera_clusterBase[CLUSTER] + 0x20000 - 1)
+#define CLUSTER1 4
+#define STACK_ADDRESS (_chimera_clusterBase[CLUSTER1] + 0x20000 - 1)
 
 extern uintptr_t volatile tohost, fromhost;
 
@@ -43,27 +43,27 @@ int main(void) {
 #endif
 
     void *stack_cluster_ptr[NUM_CLUSTER_CORES];
-    generate_snitchCluster_SPs_uniform(CLUSTER, (void *)STACK_ADDRESS, 0x2000, stack_cluster_ptr);
+    generate_snitchCluster_SPs_uniform(CLUSTER1, (void *)STACK_ADDRESS, 0x2000, stack_cluster_ptr);
 
     setup_snitchCluster_interruptHandler(clusterInterruptHandler);
 
-    set_snitchCluster_clockGating(CLUSTER, 0);
+    set_snitchCluster_clockGating(CLUSTER1, 0);
 
-    set_snitchCluster_reset(CLUSTER, 1);
+    set_snitchCluster_reset(CLUSTER1, 1);
     for (volatile int i = 0; i < 10; i++);
-    set_snitchCluster_reset(CLUSTER, 0);
+    set_snitchCluster_reset(CLUSTER1, 0);
 
     printf_log("Waiting for cluster to finish...\n");
 
     // Disable interrupts
     set_mie(0);
-    offload_snitchCluster(testReturn, NULL, stack_cluster_ptr, CLUSTER);
+    offload_snitchCluster(testReturn, NULL, stack_cluster_ptr, CLUSTER1);
 
     // Enable interrupts
     set_mie(1);
 
     // Handle tohost/fromhost communication
-    while (snitchCluster_busy(CLUSTER)) {
+    while (snitchCluster_busy(CLUSTER1)) {
 
         // Wait for tohost to be set by the device
         if (tohost != 0) {
@@ -94,10 +94,10 @@ int main(void) {
         clint_sleep_ticks(0, 10);
     }
 
-    uint32_t retVal = wait_snitchCluster_return(CLUSTER);
+    uint32_t retVal = wait_snitchCluster_return(CLUSTER1);
     retVal = retVal >> 1;
 
-    set_snitchCluster_clockGating(CLUSTER, 1);
+    set_snitchCluster_clockGating(CLUSTER1, 1);
 
     printf_log("Returned from cluster: 0x%08x (%d)\n", retVal, retVal);
 

--- a/tests/snitchCluster/snrt/src_host/test_host.c
+++ b/tests/snitchCluster/snrt/src_host/test_host.c
@@ -15,6 +15,8 @@
 
 // Include Runtime Headers
 #include "log.h"
+#include "clint.h"
+#include "util.h"
 
 // Import HAL Headers
 
@@ -53,10 +55,16 @@ int main(void) {
 
     printf_log("Waiting for cluster to finish...\n");
 
+    // Disable interrupts
+    set_mie(0);
     offload_snitchCluster(testReturn, NULL, stack_cluster_ptr, CLUSTER);
+
+    // Enable interrupts
+    set_mie(1);
 
     // Handle tohost/fromhost communication
     while (snitchCluster_busy(CLUSTER)) {
+
         // Wait for tohost to be set by the device
         if (tohost != 0) {
             volatile uint32_t syscall_addr = tohost;
@@ -81,6 +89,9 @@ int main(void) {
             // Notify cluster that syscall is done
             fromhost = syscall_addr;
         }
+
+        // Enter low-power mode until next interrupt or timeout
+        clint_sleep_ticks(0, 10);
     }
 
     uint32_t retVal = wait_snitchCluster_return(CLUSTER);


### PR DESCRIPTION
# Changelog
This PR introduces a generic test infrastructure with interrupt-based printf support and multi-cluster testing capabilities, along with utility functions for the Snitch cluster runtime.

## Added
- Generic test infrastructure in `targets/chimera-convolve/` with interrupt-based printf support
- FLL (Frequency Locked Loop) support in host runtime (`host/runtime/inc/fll.h`, `host/runtime/src/fll.c`)
- CLINT utility functions for interrupt management (`host/runtime/inc/clint.h`, `host/runtime/src/clint.c`)
- Multi-cluster test support with improved abstraction layer

## Changed
- Refactored test infrastructure to support multiple clusters simultaneously
- Updated all Snitch cluster tests (`matmul`, `simpleOffload`, `snrt`) to use the new generic test infrastructure
- Updated `crt0.S` startup code across multiple targets (`chimera-convolve`, `chimera-host`, `chimera-open`)
- Downgrade CMake Version for Ubuntu compatibility

## Fixed
- Improved test abstraction and consistency across different cluster configurations
- Better interrupt handling and printf functionality in test environment

## Checklist

1. [x] The PR is rebased on the latest `devel` commit and pointing to `devel`.
2. [x] Your PR reviewed and approved.
2. [x] The documentation is updated.
3. [x] All checks are passing.